### PR TITLE
Force Guava 18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,12 @@ buildscript {
         jcenter()
     }
 
+    configurations.all {
+        resolutionStrategy {
+            force 'com.google.guava:guava:18.0'
+        }
+    }
+
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.0'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.0.1'

--- a/worldedit-core/build.gradle
+++ b/worldedit-core/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile 'de.schlichtherle:truezip:6.8.3'
     compile 'rhino:js:1.7R2'
     compile 'org.yaml:snakeyaml:1.9'
-    compile 'com.google.guava:guava:17.0'
+    compile 'com.google.guava:guava:18.0'
     compile 'com.sk89q:jchronic:0.2.4a'
     compile 'com.google.code.findbugs:jsr305:1.3.9'
     compile 'com.thoughtworks.paranamer:paranamer:2.6'


### PR DESCRIPTION
Fixes the Forge build by forcing transient dependencies to Guava 18. Also upgraded core guava.