### PR TITLE
Fix Forge CUI handler

### DIFF
--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
@@ -34,8 +34,8 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
-import net.minecraft.network.play.server.S3FPacketCustomPayload;
 import net.minecraft.util.ChatComponentText;
+import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
 import io.netty.buffer.Unpooled;
 
 import javax.annotation.Nullable;
@@ -117,8 +117,7 @@ public class ForgePlayer extends AbstractPlayerActor {
             send = send + "|" + StringUtil.joinString(params, "|");
         }
         PacketBuffer buffer = new PacketBuffer(Unpooled.copiedBuffer(send.getBytes(WECUIPacketHandler.UTF_8_CHARSET)));
-        S3FPacketCustomPayload packet = new S3FPacketCustomPayload(ForgeWorldEdit.CUI_PLUGIN_CHANNEL, buffer);
-        this.player.playerNetServerHandler.sendPacket(packet);
+        WECUIPacketHandler.WECUI_CHANNEL.sendTo(new FMLProxyPacket(buffer, ForgeWorldEdit.CUI_PLUGIN_CHANNEL), player);
     }
 
     @Override

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
@@ -34,8 +34,8 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.server.S3FPacketCustomPayload;
 import net.minecraft.util.ChatComponentText;
-import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
 import io.netty.buffer.Unpooled;
 
 import javax.annotation.Nullable;
@@ -117,7 +117,8 @@ public class ForgePlayer extends AbstractPlayerActor {
             send = send + "|" + StringUtil.joinString(params, "|");
         }
         PacketBuffer buffer = new PacketBuffer(Unpooled.copiedBuffer(send.getBytes(WECUIPacketHandler.UTF_8_CHARSET)));
-        WECUIPacketHandler.WECUI_CHANNEL.sendTo(new FMLProxyPacket(buffer, ForgeWorldEdit.CUI_PLUGIN_CHANNEL), player);
+        S3FPacketCustomPayload packet = new S3FPacketCustomPayload(ForgeWorldEdit.CUI_PLUGIN_CHANNEL, buffer);
+        this.player.playerNetServerHandler.sendPacket(packet);
     }
 
     @Override

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
@@ -95,6 +95,7 @@ public class ForgeWorldEdit {
     @EventHandler
     public void init(FMLInitializationEvent event) {
         MinecraftForge.EVENT_BUS.register(this);
+        WECUIPacketHandler.init();
         proxy.registerHandlers();
     }
 

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/WECUIPacketHandler.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/WECUIPacketHandler.java
@@ -23,9 +23,13 @@ import java.nio.charset.Charset;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.NetHandlerPlayServer;
-import net.minecraft.network.play.client.C17PacketCustomPayload;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.ThreadQuickExitException;
+import net.minecraft.network.play.server.S20PacketEntityProperties;
+import net.minecraft.network.play.server.S3FPacketCustomPayload;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.network.FMLEventChannel;
+import net.minecraftforge.fml.common.network.FMLNetworkEvent.ClientCustomPacketEvent;
 import net.minecraftforge.fml.common.network.FMLNetworkEvent.ServerCustomPacketEvent;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 
@@ -33,7 +37,7 @@ import com.sk89q.worldedit.LocalSession;
 
 public class WECUIPacketHandler {
     public static final Charset UTF_8_CHARSET = Charset.forName("UTF-8");
-    private static FMLEventChannel WECUI_CHANNEL;
+    public static FMLEventChannel WECUI_CHANNEL;
     
     public static void init() {
          WECUI_CHANNEL = NetworkRegistry.INSTANCE.newEventDrivenChannel(ForgeWorldEdit.CUI_PLUGIN_CHANNEL);
@@ -42,7 +46,6 @@ public class WECUIPacketHandler {
 
     @SubscribeEvent
     public void onPacketData(ServerCustomPacketEvent event) {
-        C17PacketCustomPayload rawPacket = (C17PacketCustomPayload) event.packet.toC17Packet();
         if (event.packet.channel().equals(ForgeWorldEdit.CUI_PLUGIN_CHANNEL)) {
             EntityPlayerMP player = getPlayerFromEvent(event);
             LocalSession session = ForgeWorldEdit.inst.getSession((EntityPlayerMP) player);
@@ -50,9 +53,18 @@ public class WECUIPacketHandler {
             if (session.hasCUISupport()) {
                 return;
             }
-        
-            String text = new String(rawPacket.getBufferData().array(), UTF_8_CHARSET);
+
+            String text = event.packet.payload().toString(UTF_8_CHARSET);
             session.handleCUIInitializationMessage(text);
+            session.describeCUI(ForgeWorldEdit.inst.wrap(player));
+        }
+    }
+    
+    @SubscribeEvent
+    public void callProcessPacket(ClientCustomPacketEvent event) {
+        try {
+            new S3FPacketCustomPayload(event.packet.channel(), new PacketBuffer(event.packet.payload())).processPacket(event.handler);
+        } catch (ThreadQuickExitException suppress) {
         }
     }
 


### PR DESCRIPTION
I forgot to register it, and there was a conflict with LiteLoader channel listening. Target is the forge 1.8 branch, although I could backport it.