### PR TITLE
Add stone to usesData HashSet.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/BlockType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/BlockType.java
@@ -728,6 +728,7 @@ public enum BlockType {
      */
     private static final Set<Integer> usesData = new HashSet<Integer>();
     static {
+        usesData.add(BlockID.STONE);
         usesData.add(BlockID.DIRT);
         usesData.add(BlockID.WOOD);
         usesData.add(BlockID.SAPLING);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/ItemType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/ItemType.java
@@ -680,6 +680,7 @@ public enum ItemType {
         usesDamageValue.add(ItemID.GOLD_APPLE);
         usesDamageValue.add(ItemID.RAW_FISH);
         usesDamageValue.add(ItemID.COOKED_FISH);
+        usesDamageValue.add(ItemID.BANNER);
     }
 
     /**


### PR DESCRIPTION
When WorldGuard's 'protection.item-durability' option is set to false, breaking a block when holding a stone variant in your hand (granite, diorite, andesite, and their polished versions) will cause the item being held to [turn back to stone](https://github.com/sk89q/WorldGuard/blob/a1a6ee7107bd8c3f86bf213214dd83a696f93dec/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardBlockListener.java#L109).