### PR TITLE
Fix for WORLDEDIT-3270

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockDataCyler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockDataCyler.java
@@ -19,9 +19,12 @@
 
 package com.sk89q.worldedit.command.tool;
 
+import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
+import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.blocks.BaseBlock;
+import com.sk89q.worldedit.blocks.BlockData;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Platform;
@@ -54,12 +57,19 @@ public class BlockDataCyler implements DoubleActionBlockTool {
         }
 
         int increment = forward ? 1 : -1;
-        data = (new BaseBlock(type, data)).cycleData(increment);
+        BaseBlock block = new BaseBlock(type, BlockData.cycle(type, data, increment));
+        EditSession editSession = session.createEditSession(player);
 
         if (data < 0) {
             player.printError("That block's data cannot be cycled!");
         } else {
-            world.setBlockData(clicked.toVector(), data);
+            try {
+                editSession.setBlock(clicked.toVector(), block);
+            } catch (MaxChangedBlocksException e) {
+                player.printError("Max blocks change limit reached.");
+            } finally {
+                session.remember(editSession);
+            }
         }
 
         return true;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockReplacer.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockReplacer.java
@@ -46,10 +46,9 @@ public class BlockReplacer implements DoubleActionBlockTool {
 
     @Override
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, com.sk89q.worldedit.util.Location clicked) {
-BlockBag bag = session.getBlockBag(player);
+        BlockBag bag = session.getBlockBag(player);
 
-        World world = (World) clicked.getExtent();
-        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory().getEditSession(world, -1, bag, player);
+        EditSession editSession = session.createEditSession(player);
 
         try {
             editSession.setBlock(clicked.toVector(), targetBlock);
@@ -68,7 +67,7 @@ BlockBag bag = session.getBlockBag(player);
     @Override
     public boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session, com.sk89q.worldedit.util.Location clicked) {
         World world = (World) clicked.getExtent();
-        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory().getEditSession(world, -1, player);
+        EditSession editSession = session.createEditSession(player);
         targetBlock = (editSession).getBlock(clicked.toVector());
         BlockType type = BlockType.fromID(targetBlock.getType());
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/QueryTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/QueryTool.java
@@ -43,7 +43,7 @@ public class QueryTool implements BlockTool {
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, com.sk89q.worldedit.util.Location clicked) {
 
         World world = (World) clicked.getExtent();
-        EditSession editSession = WorldEdit.getInstance().getEditSessionFactory().getEditSession(world, 0, player);
+        EditSession editSession = session.createEditSession(player);
         BaseBlock block = (editSession).rawGetBlock(clicked.toVector());
         BlockType type = BlockType.fromID(block.getType());
 


### PR DESCRIPTION
[WORLDEDIT-3270](http://youtrack.sk89q.com/issue/WORLDEDIT-3270) described how /repl could be used to bypass a plots protection. This PR proposes fixes to /repl and two additional tools which were able to change blocks regardless of a player's gmask.

While the issue was flagged as invalid as the bug was believed to lie within PlotMe, it was instead caused through the loss of the player's gmask which was used by PlotMe to implement WorldEdit protection.

The /info tool was also found to generate the EditSession directly from the factory, though this didn't produce any observable effects as it only queries blocks.

The /cycler tool did not use any EditSession, instead calling the setBlockData directly on the world.