### PR TITLE
Fix command exceptions.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/command/parametric/ExceptionConverterHelper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/command/parametric/ExceptionConverterHelper.java
@@ -100,8 +100,10 @@ public abstract class ExceptionConverterHelper implements ExceptionConverter {
                 return 0;
             } else if (cls.isAssignableFrom(o.cls)) {
                 return 1;
-            } else {
+            } else if (o.cls.isAssignableFrom(cls)) {
                 return -1;
+            } else {
+                return cls.getCanonicalName().compareTo(o.cls.getCanonicalName());
             }
         }
     }


### PR DESCRIPTION
Fixes exceptions thrown within command handlers incorrectly propagating to a stacktrace.

The command framework handles exceptions thrown by command handlers in ExceptionConverter. The implementation of this, ExceptionConverterHelper, stores a list of exception handlers sorted by how specific the handles exception is.

Under certain JVMs, handled exceptions weren't being caught by this converter, but instead caused a stacktrace in console. This was caused by the general-case handler being sorted higher in the list than some specifics. This incorrect sorting was caused by an error in the compareTo method of the ExceptionHandler objects that were used to ensure ordering.

The previous implementation violated the contract that compareTo must be behave the same way when operands are reversed and that it is transitive. Any classes that were not equal, or a superclass of another were returned as being "less than".

The new implementation tests if classes are superclasses of each other, otherwise falls back to alphabetical sorting on canonical name.