### PR TITLE
Added SchematicEvent(WritePre, Write, WritePost). Added "Mapping" tag to the correct alias IDs in forge mods that load schematics.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/event/platform/SchematicEvent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/event/platform/SchematicEvent.java
@@ -1,0 +1,174 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.event.platform;
+
+import java.util.HashMap;
+
+import com.sk89q.jnbt.*;
+import com.sk89q.worldedit.event.Cancellable;
+import com.sk89q.worldedit.event.Event;
+import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.sk89q.worldedit.extent.clipboard.io.SchematicWriter;
+import com.sk89q.worldedit.world.registry.WorldData;
+
+/**
+ * Called when a schematic is saved
+ */
+public abstract class SchematicEvent extends Event {
+
+    private SchematicWriter schematicWriter;
+    private Clipboard clipboard;
+    private WorldData data;
+
+    /**
+     * Create a new event.
+     */
+    public SchematicEvent(SchematicWriter schematicWriter, Clipboard clipboard,
+            WorldData data) {
+        this.clipboard = clipboard;
+        this.data = data;
+        this.schematicWriter = schematicWriter;
+    }
+
+    /**
+     * @return CuboidClipboard instance used to store the current clipboard.
+     */
+    public Clipboard getClipboard() {
+        return this.clipboard;
+    }
+
+    /**
+     * @return WorldData instance used to store the current clipboard's world
+     *         data.
+     */
+    public WorldData getWorldData() {
+        return data;
+    }
+
+    /**
+     * @return SchematicWriter instance for this schematic.
+     */
+    public SchematicWriter getSchematicWriter() {
+        return schematicWriter;
+    }
+
+    public static class WritePre extends SchematicEvent implements Cancellable {
+
+        private boolean cancelled;
+        private NBTOutputStream outputStream;
+
+        /**
+         * Create a new pre write event.
+         * 
+         * @param outputStream
+         */
+        public WritePre(SchematicWriter schematicWriter, Clipboard clipboard,
+                WorldData data, NBTOutputStream outputStream) {
+            super(schematicWriter, clipboard, data);
+            this.outputStream = outputStream;
+        }
+
+        public NBTOutputStream getOutputStream() {
+            return outputStream;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return this.cancelled;
+        }
+
+        @Override
+        public void setCancelled(boolean cancelled) {
+            this.cancelled = cancelled;
+        }
+    }
+
+    public static class Write extends SchematicEvent implements Cancellable {
+
+        private boolean cancelled;
+        private CompoundTag schematicTag;
+        private HashMap<String, Tag> schematic;
+        private NBTOutputStream outputStream;
+
+        /**
+         * Create a new write event.
+         * 
+         * @param outputStream
+         */
+        public Write(SchematicWriter schematicWriter, Clipboard clipboard,
+                WorldData data, CompoundTag schematicTag,
+                HashMap<String, Tag> schematic, NBTOutputStream outputStream) {
+            super(schematicWriter, clipboard, data);
+            this.schematicTag = schematicTag;
+            this.schematic = schematic;
+            this.outputStream = outputStream;
+        }
+
+        /**
+         * @return NBT Compound tag created for the schematic.
+         */
+        public CompoundTag getSchematicTag() {
+            return this.schematicTag;
+        }
+
+        /**
+         * @return HashMap<String, Tag> instance containing the schematic's
+         *         values.
+         */
+        public HashMap<String, Tag> getSchematicMap() {
+            return this.schematic;
+        }
+
+        public NBTOutputStream getOutputStream() {
+            return outputStream;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return this.cancelled;
+        }
+
+        @Override
+        public void setCancelled(boolean cancelled) {
+            this.cancelled = cancelled;
+        }
+    }
+
+    public static class WritePost extends SchematicEvent {
+
+        private CompoundTag schematicTag;
+
+        /**
+         * Create a new post write event.
+         */
+        public WritePost(SchematicWriter schematicWriter, Clipboard clipboard,
+                WorldData data, CompoundTag schematicTag) {
+            super(schematicWriter, clipboard, data);
+            this.schematicTag = schematicTag;
+        }
+
+        /**
+         * @return NBT Compound tag created for the schematic.
+         */
+        public CompoundTag getSchematicTag() {
+            return this.schematicTag;
+        }
+    }
+}

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/CommonProxy.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/CommonProxy.java
@@ -19,13 +19,57 @@
 
 package com.sk89q.worldedit.forge;
 
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.block.Block;
+
+import com.sk89q.jnbt.*;
+import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.blocks.BaseBlock;
+import com.sk89q.worldedit.event.platform.SchematicEvent;
+import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.forge.gui.GuiHandler;
+import com.sk89q.worldedit.util.eventbus.Subscribe;
+
 import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.common.registry.GameRegistry;
 
 public class CommonProxy {
 
     public void registerHandlers() {
         NetworkRegistry.INSTANCE.registerGuiHandler(ForgeWorldEdit.inst, new GuiHandler());
+        WorldEdit.getInstance().getEventBus().register(this);
     }
 
+    /**
+     * An event called when a schematic is saved.
+     * @param event - The event instance.
+     */
+    @Subscribe
+    public void onSchematicSave(SchematicEvent.Write event) {
+        Map<String, Tag> idMap = new HashMap<String, Tag>();
+        Clipboard clipboard = event.getClipboard();
+
+        for (Vector point : clipboard.getRegion()) {
+            BaseBlock block = clipboard.getBlock(point);
+            String alias = GameRegistry.findUniqueIdentifierFor(Block.getBlockById(block.getId())).toString();
+            if (!mappingExists(alias, idMap)) idMap.put(alias, new ShortTag((short) block.getId()));
+        }
+
+        event.getSchematicMap().put("Mapping", new CompoundTag(idMap));
+    }
+
+    /**
+     * Used to check if a block alias exists in the current id map.
+     * 
+     * @param alias - The alias being searched for.
+     * @param idMap - The id map that is being checked.
+     * @return Return true if the mapping exists in the id map.
+     */
+    public boolean mappingExists(String alias, Map<String, Tag> idMap) {
+        return alias != null && idMap != null && idMap.containsKey(alias);
+    }
 }


### PR DESCRIPTION
Added SchematicEvent(WritePre, Write, WritePost), necessary for the main feature.
Added "Mapping" tag to schematics saved using the Forge Adapter. This allows for mapping numerical block IDs to the correct alias IDs in forge mods that load schematics.

For example, if a schematic contains gold blocks, a new CompoundTag will be added to the "ForgeIdMap" ListTag containing the block id(41), and the alias id used in Forge mods(minecraft:gold_block). This has been tested with vanilla and mod blocks, and is functional. It will not add duplicate ID mappings or ID mappings that are not used in the schematic.

This was done using a new event I added called "SchematicEvent". There are 3 sub events; WritePre, Write, and WritePost. The mappings use SchematicEvent.Write to inject the mapping values into the schematic.

Sorry for basically creating a duplicate PR, but the previous one got screwed up.