### PR TITLE
Add support for delegating permissions checks to Sponge when installed

### DIFF
--- a/config/checkstyle/import-control.xml
+++ b/config/checkstyle/import-control.xml
@@ -54,6 +54,7 @@
       <allow pkg="org.apache.logging.log4j"/>
       <allow pkg="org.lwjgl"/>
       <allow pkg="io.netty.buffer"/>
+      <allow pkg="org.spongepowered.api" />
     </subpackage>
   </subpackage>
 </import-control>

--- a/worldedit-forge/build.gradle
+++ b/worldedit-forge/build.gradle
@@ -15,7 +15,12 @@ apply plugin: 'forge'
 
 dependencies {
     compile project(':worldedit-core')
+    compile 'org.spongepowered:spongeapi:2.1-SNAPSHOT'
     testCompile group: 'org.mockito', name: 'mockito-core', version:'1.9.0-rc1'
+}
+
+repositories {
+    maven { url ="https://repo.spongepowered.org/maven" }
 }
 
 minecraft {
@@ -31,7 +36,7 @@ project.archivesBaseName = "${project.archivesBaseName}-mc${minecraft.version}"
 processResources {
     from (sourceSets.main.resources.srcDirs) {
         expand 'version': project.version,
-                'mcVersion': project.minecraft.version, 
+                'mcVersion': project.minecraft.version,
                 'forgeVersion': project.minecraft.forgeVersion,
                 'internalVersion': project.internalVersion
         include 'mcmod.info'

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePermissionsProvider.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePermissionsProvider.java
@@ -23,6 +23,7 @@ import net.minecraft.command.ICommand;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.world.WorldSettings.GameType;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import org.spongepowered.api.entity.player.Player;
 
 public interface ForgePermissionsProvider {
 
@@ -48,5 +49,18 @@ public interface ForgePermissionsProvider {
 
         @Override
         public void registerPermission(ICommand command, String permission) {}
+    }
+
+    public static class SpongePermissionsProvider implements ForgePermissionsProvider {
+
+        @Override
+        public boolean hasPermission(EntityPlayerMP player, String permission) {
+            return ((Player) player).hasPermission(permission);
+        }
+
+        @Override
+        public void registerPermission(ICommand command, String permission) {
+
+        }
     }
 }

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
@@ -36,6 +36,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.CommandEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.Mod.Instance;
@@ -60,7 +61,7 @@ import static net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 /**
  * The Forge implementation of WorldEdit.
  */
-@Mod(modid = ForgeWorldEdit.MOD_ID, name = "WorldEdit", version = "%VERSION%", acceptableRemoteVersions = "*")
+@Mod(modid = ForgeWorldEdit.MOD_ID, name = "WorldEdit", version = "%VERSION%", acceptableRemoteVersions = "*", dependencies = "after:Sponge")
 public class ForgeWorldEdit {
 
     public static Logger logger;
@@ -116,7 +117,12 @@ public class ForgeWorldEdit {
         this.platform = new ForgePlatform(this);
 
         WorldEdit.getInstance().getPlatformManager().register(platform);
-        this.provider = new ForgePermissionsProvider.VanillaPermissionsProvider(platform);
+
+        if (Loader.isModLoaded("Sponge")) {
+            this.provider = new ForgePermissionsProvider.SpongePermissionsProvider();
+        } else {
+            this.provider = new ForgePermissionsProvider.VanillaPermissionsProvider(platform);
+        }
     }
 
     @EventHandler


### PR DESCRIPTION
This allows Sponge permissions plugins to be used for permissions checks without having to write a whole Sponge implementation. It should continue to work as previously if Sponge is not installed.

@luacs1998 since you did this system, any thoughts?