### PR TITLE
Fixed wrong torch metadata.

### DIFF
--- a/worldedit-core/src/main/resources/com/sk89q/worldedit/world/registry/blocks.json
+++ b/worldedit-core/src/main/resources/com/sk89q/worldedit/world/registry/blocks.json
@@ -1769,8 +1769,8 @@
         "values": {
           "east": { "data": 1, "direction": [1, 0, 0] },
           "west": { "data": 2, "direction": [-1, 0, 0] },
-          "north": { "data": 3, "direction": [0, 0, -1] },
-          "south": { "data": 4, "direction": [0, 0, 1] },
+          "south": { "data": 3, "direction": [0, 0, 1] },
+          "north": { "data": 4, "direction": [0, 0, -1] },
           "up": { "data": 5, "direction": [0, 1, 0] }
         }
       }
@@ -2685,8 +2685,8 @@
         "values": {
           "east": { "data": 1, "direction": [1, 0, 0] },
           "west": { "data": 2, "direction": [-1, 0, 0] },
-          "north": { "data": 3, "direction": [0, 0, -1] },
-          "south": { "data": 4, "direction": [0, 0, 1] },
+          "south": { "data": 3, "direction": [0, 0, 1] },
+          "north": { "data": 4, "direction": [0, 0, -1] },
           "up": { "data": 5, "direction": [0, 1, 0] }
         }
       }
@@ -2725,8 +2725,8 @@
         "values": {
           "east": { "data": 1, "direction": [1, 0, 0] },
           "west": { "data": 2, "direction": [-1, 0, 0] },
-          "north": { "data": 3, "direction": [0, 0, -1] },
-          "south": { "data": 4, "direction": [0, 0, 1] },
+          "south": { "data": 3, "direction": [0, 0, 1] },
+          "north": { "data": 4, "direction": [0, 0, -1] },
           "up": { "data": 5, "direction": [0, 1, 0] }
         }
       }


### PR DESCRIPTION
When using //rotate, normal torches, powered redstone torches and unpowered redstone torches would rotate unexpectedly. This was caused by swapped metadata 3 and 4 (North and South). This commit fixes that bug.