### PR TITLE
Improve Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: java
 notifications:
   email: false
 before_install: chmod +x gradlew
-install: ./gradlew setupCIWorkspace -S
-script: ./gradlew build -S
+install: ./gradlew setupCIWorkspace -s
+script: ./gradlew build -s
 jdk:
   - oraclejdk8
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,10 @@ jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk6
+# Caching for Gradle files, prevents hitting Maven too much.
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ notifications:
   email: false
 before_install: chmod +x gradlew
 install: ./gradlew setupCIWorkspace -S
-matrix:
-  include:
-  - jdk: oraclejdk7
-    script: ./gradlew build -S
+script: ./gradlew build -S
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk6

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
+# Faster builds without sudo.
+sudo: false


### PR DESCRIPTION
This allows Travis to build faster and on all the JDKs. I also rewrote some of the `Closer` code to compile on Java 6 with the use of `JarFile` and `ZipFile`, which needs to be double-checked for accuracy.