### PR TITLE
Add support for 1.9 doors on MultiStageReorder

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/BlockType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/BlockType.java
@@ -497,6 +497,11 @@ public enum BlockType {
     static {
         shouldPlaceFinal.add(BlockID.SIGN_POST);
         shouldPlaceFinal.add(BlockID.WOODEN_DOOR);
+        shouldPlaceFinal.add(BlockID.ACACIA_DOOR);
+        shouldPlaceFinal.add(BlockID.BIRCH_DOOR);
+        shouldPlaceFinal.add(BlockID.JUNGLE_DOOR);
+        shouldPlaceFinal.add(BlockID.DARK_OAK_DOOR);
+        shouldPlaceFinal.add(BlockID.SPRUCE_DOOR);
         shouldPlaceFinal.add(BlockID.WALL_SIGN);
         shouldPlaceFinal.add(BlockID.IRON_DOOR);
         shouldPlaceFinal.add(BlockID.CACTUS);
@@ -920,6 +925,11 @@ public enum BlockType {
         isRedstoneBlock.add(BlockID.STONE_BUTTON);
         isRedstoneBlock.add(BlockID.REDSTONE_WIRE);
         isRedstoneBlock.add(BlockID.WOODEN_DOOR);
+        isRedstoneBlock.add(BlockID.ACACIA_DOOR);
+        isRedstoneBlock.add(BlockID.BIRCH_DOOR);
+        isRedstoneBlock.add(BlockID.JUNGLE_DOOR);
+        isRedstoneBlock.add(BlockID.DARK_OAK_DOOR);
+        isRedstoneBlock.add(BlockID.SPRUCE_DOOR);
         isRedstoneBlock.add(BlockID.IRON_DOOR);
         isRedstoneBlock.add(BlockID.TNT);
         isRedstoneBlock.add(BlockID.DISPENSER);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/BlockType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/BlockType.java
@@ -23,6 +23,7 @@ import com.sk89q.util.StringUtil;
 import com.sk89q.worldedit.PlayerDirection;
 
 import javax.annotation.Nullable;
+
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1520,6 +1521,12 @@ public enum BlockType {
         addIdentity(BlockID.PACKED_ICE);
         addIdentities(BlockID.STAINED_GLASS_PANE, 16);
         addIdentities(BlockID.DOUBLE_PLANT, 6);
+
+        addIdentities(BlockID.ACACIA_DOOR, 8); // rule 2
+        addIdentities(BlockID.BIRCH_DOOR, 8); // rule 2
+        addIdentities(BlockID.JUNGLE_DOOR, 8); // rule 2
+        addIdentities(BlockID.DARK_OAK_DOOR, 8); // rule 2
+        addIdentities(BlockID.SPRUCE_DOOR, 8); // rule 2
     }
 
     /**


### PR DESCRIPTION
The MultiStageReorder algorithm uses the BlockType.shouldPlaceFinal set in order to attach the superior and inferior blocks of doors correctly. I also added the new doors to the BlockType.isRedstoneBlock collection. Those doors are problably missing from more collections or further configuration inside the BlockType class, but these two are the ones I'm sure of. This should allow to use fast=false and place the doors correctly.