### PR TITLE
Fix rotation of item frames

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/entity/ExtentEntityCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/entity/ExtentEntityCopy.java
@@ -131,6 +131,7 @@ public class ExtentEntityCopy implements EntityFunction {
             boolean hasTilePosition = tag.containsKey("TileX") && tag.containsKey("TileY") && tag.containsKey("TileZ");
             boolean hasDirection = tag.containsKey("Direction");
             boolean hasLegacyDirection = tag.containsKey("Dir");
+            boolean hasFacing = tag.containsKey("Facing");
 
             if (hasTilePosition) {
                 Vector tilePosition = new Vector(tag.asInt("TileX"), tag.asInt("TileY"), tag.asInt("TileZ"));
@@ -141,15 +142,25 @@ public class ExtentEntityCopy implements EntityFunction {
                         .putInt("TileY", newTilePosition.getBlockY())
                         .putInt("TileZ", newTilePosition.getBlockZ());
 
-                if (hasDirection || hasLegacyDirection) {
-                    int d = hasDirection ? tag.asInt("Direction") : MCDirections.fromLegacyHanging((byte) tag.asInt("Dir"));
+                if (hasDirection || hasLegacyDirection || hasFacing) {
+                    int d;
+                    if (hasDirection) {
+                        d = tag.asInt("Direction");
+                    } else if (hasLegacyDirection) {
+                        d = MCDirections.fromLegacyHanging((byte) tag.asInt("Dir"));
+                    } else {
+                        d = tag.asInt("Facing");
+                    }
+
                     Direction direction = MCDirections.fromHanging(d);
 
                     if (direction != null) {
                         Vector vector = transform.apply(direction.toVector()).subtract(transform.apply(Vector.ZERO)).normalize();
                         Direction newDirection = Direction.findClosest(vector, Flag.CARDINAL);
 
-                        builder.putByte("Direction", (byte) MCDirections.toHanging(newDirection));
+                        byte hangingByte = (byte) MCDirections.toHanging(newDirection);
+                        builder.putByte("Direction", hangingByte);
+                        builder.putByte("Facing", hangingByte);
                         builder.putByte("Dir", MCDirections.toLegacyHanging(MCDirections.toHanging(newDirection)));
                     }
                 }


### PR DESCRIPTION
Minecraft 1.8 introduced a new tag named 'Facing' which holds the direction item frames face. Pre-1.8 'Dir' and 'Direction' were used instead.
See http://minecraft.gamepedia.com/Item_Frame#Data_values

Currently item frames pop off walls after rotating because they are facing the wrong direction. This commit fixes that issue.