### PR TITLE
Apply transformations to NBT data of tile entities (fixes rotation of skulls)

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/helper/MCDirections.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/helper/MCDirections.java
@@ -77,4 +77,82 @@ public final class MCDirections {
         }
     }
 
+    public static Direction fromRotation(int i) {
+        switch (i) {
+            case 0:
+                return Direction.SOUTH;
+            case 1:
+                return Direction.SOUTH_SOUTHWEST;
+            case 2:
+                return Direction.SOUTHWEST;
+            case 3:
+                return Direction.WEST_SOUTHWEST;
+            case 4:
+                return Direction.WEST;
+            case 5:
+                return Direction.WEST_NORTHWEST;
+            case 6:
+                return Direction.NORTHWEST;
+            case 7:
+                return Direction.NORTH_NORTHWEST;
+            case 8:
+                return Direction.NORTH;
+            case 9:
+                return Direction.NORTH_NORTHEAST;
+            case 10:
+                return Direction.NORTHEAST;
+            case 11:
+                return Direction.EAST_NORTHEAST;
+            case 12:
+                return Direction.EAST;
+            case 13:
+                return Direction.EAST_SOUTHEAST;
+            case 14:
+                return Direction.SOUTHEAST;
+            case 15:
+                return Direction.SOUTH_SOUTHEAST;
+            default:
+                return Direction.NORTH;
+        }
+    }
+
+    public static int toRotation(Direction direction) {
+        switch (direction) {
+            case SOUTH:
+                return 0;
+            case SOUTH_SOUTHWEST:
+                return 1;
+            case SOUTHWEST:
+                return 2;
+            case WEST_SOUTHWEST:
+                return 3;
+            case WEST:
+                return 4;
+            case WEST_NORTHWEST:
+                return 5;
+            case NORTHWEST:
+                return 6;
+            case NORTH_NORTHWEST:
+                return 7;
+            case NORTH:
+                return 8;
+            case NORTH_NORTHEAST:
+                return 9;
+            case NORTHEAST:
+                return 10;
+            case EAST_NORTHEAST:
+                return 11;
+            case EAST:
+                return 12;
+            case EAST_SOUTHEAST:
+                return 13;
+            case SOUTHEAST:
+                return 14;
+            case SOUTH_SOUTHEAST:
+                return 15;
+            default:
+                return 0;
+        }
+    }
+
 }


### PR DESCRIPTION
Skulls store their rotation in a NBT tag called 'Rot' if they're standing on the ground.
This commit modifies ExtentBlockCopy to set this tag to ensure that skulls are rotated correctly.
I'm not quite sure if this is the right place to do so though.