### PR TITLE
Replace RightClickEmpty with RightClickItem.

### DIFF
--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
@@ -196,7 +196,7 @@ public class ForgeWorldEdit {
             if (we.handleRightClick(player)) {
                 event.setCanceled(true);
             }
-        } else if (event instanceof PlayerInteractEvent.RightClickEmpty) {
+        } else if (event instanceof PlayerInteractEvent.RightClickItem) {
             if (we.handleRightClick(player)) {
                 event.setCanceled(true);
             }


### PR DESCRIPTION
RightClickEmpty is not fired on the server. RightClickItem fires once
for the same event (a right click in air). This fixes brush and other tools that rely on air
clicks.