### PR TITLE
Fix NPE when rotating hanging entities

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/entity/ExtentEntityCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/entity/ExtentEntityCopy.java
@@ -158,10 +158,12 @@ public class ExtentEntityCopy implements EntityFunction {
                         Vector vector = transform.apply(direction.toVector()).subtract(transform.apply(Vector.ZERO)).normalize();
                         Direction newDirection = Direction.findClosest(vector, Flag.CARDINAL);
 
-                        byte hangingByte = (byte) MCDirections.toHanging(newDirection);
-                        builder.putByte("Direction", hangingByte);
-                        builder.putByte("Facing", hangingByte);
-                        builder.putByte("Dir", MCDirections.toLegacyHanging(MCDirections.toHanging(newDirection)));
+                        if (newDirection != null) {
+                            byte hangingByte = (byte) MCDirections.toHanging(newDirection);
+                            builder.putByte("Direction", hangingByte);
+                            builder.putByte("Facing", hangingByte);
+                            builder.putByte("Dir", MCDirections.toLegacyHanging(MCDirections.toHanging(newDirection)));
+                        }
                     }
                 }
 


### PR DESCRIPTION
newDirection can be null if we try to rotate hanging entities around the x- or z-axis.

If we don't check for null, we get a NPE:
```
[WorldEdit] An unexpected error while handling a WorldEdit command
java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_92]
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_92]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_92]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:1.8.0_92]
	at com.sk89q.worldedit.util.command.parametric.ParametricCallable.call(ParametricCallable.java:243) ~[worldedit-bukkit-6.1.3-SNAPSHOT-dist.jar:?]
	at com.sk89q.worldedit.util.command.SimpleDispatcher.call(SimpleDispatcher.java:125) ~[worldedit-bukkit-6.1.3-SNAPSHOT-dist.jar:?]
	at com.sk89q.worldedit.extension.platform.CommandManager.handleCommand(CommandManager.java:270) [worldedit-bukkit-6.1.3-SNAPSHOT-dist.jar:?]
	at sun.reflect.GeneratedMethodAccessor12.invoke(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_92]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:1.8.0_92]
	at com.sk89q.worldedit.util.eventbus.MethodEventHandler.dispatch(MethodEventHandler.java:58) [worldedit-bukkit-6.1.3-SNAPSHOT-dist.jar:?]
	at com.sk89q.worldedit.util.eventbus.EventHandler.handleEvent(EventHandler.java:73) [worldedit-bukkit-6.1.3-SNAPSHOT-dist.jar:?]
	at com.sk89q.worldedit.util.eventbus.EventBus.dispatch(EventBus.java:187) [worldedit-bukkit-6.1.3-SNAPSHOT-dist.jar:?]
	at com.sk89q.worldedit.util.eventbus.EventBus.post(EventBus.java:173) [worldedit-bukkit-6.1.3-SNAPSHOT-dist.jar:?]
	at com.sk89q.worldedit.bukkit.WorldEditPlugin.onCommand(WorldEditPlugin.java:247) [worldedit-bukkit-6.1.3-SNAPSHOT-dist.jar:?]
	at com.sk89q.bukkit.util.DynamicPluginCommand.execute(DynamicPluginCommand.java:54) [worldedit-bukkit-6.1.3-SNAPSHOT-dist.jar:?]
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:142) [craftbukkit.jar:git-Spigot-e000104-4cb3258]
	at org.bukkit.craftbukkit.v1_9_R1.CraftServer.dispatchCommand(CraftServer.java:645) [craftbukkit.jar:git-Spigot-e000104-4cb3258]
	at net.minecraft.server.v1_9_R1.PlayerConnection.handleCommand(PlayerConnection.java:1356) [craftbukkit.jar:git-Spigot-e000104-4cb3258]
	at net.minecraft.server.v1_9_R1.PlayerConnection.a(PlayerConnection.java:1191) [craftbukkit.jar:git-Spigot-e000104-4cb3258]
	at net.minecraft.server.v1_9_R1.PacketPlayInChat.a(PacketPlayInChat.java:45) [craftbukkit.jar:git-Spigot-e000104-4cb3258]
	at net.minecraft.server.v1_9_R1.PacketPlayInChat.a(PacketPlayInChat.java:1) [craftbukkit.jar:git-Spigot-e000104-4cb3258]
	at net.minecraft.server.v1_9_R1.PlayerConnectionUtils$1.run(SourceFile:13) [craftbukkit.jar:git-Spigot-e000104-4cb3258]
	at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) [?:1.8.0_92]
	at java.util.concurrent.FutureTask.run(Unknown Source) [?:1.8.0_92]
	at net.minecraft.server.v1_9_R1.SystemUtils.a(SourceFile:45) [craftbukkit.jar:git-Spigot-e000104-4cb3258]
	at net.minecraft.server.v1_9_R1.MinecraftServer.D(MinecraftServer.java:721) [craftbukkit.jar:git-Spigot-e000104-4cb3258]
	at net.minecraft.server.v1_9_R1.DedicatedServer.D(DedicatedServer.java:400) [craftbukkit.jar:git-Spigot-e000104-4cb3258]
	at net.minecraft.server.v1_9_R1.MinecraftServer.C(MinecraftServer.java:660) [craftbukkit.jar:git-Spigot-e000104-4cb3258]
	at net.minecraft.server.v1_9_R1.MinecraftServer.run(MinecraftServer.java:559) [craftbukkit.jar:git-Spigot-e000104-4cb3258]
	at java.lang.Thread.run(Unknown Source) [?:1.8.0_92]
Caused by: java.lang.NullPointerException
	at com.sk89q.worldedit.internal.helper.MCDirections.toHanging(MCDirections.java:48) ~[?:?]
	at com.sk89q.worldedit.function.entity.ExtentEntityCopy.transformNbtData(ExtentEntityCopy.java:161) ~[?:?]
	at com.sk89q.worldedit.function.entity.ExtentEntityCopy.apply(ExtentEntityCopy.java:104) ~[?:?]
	at com.sk89q.worldedit.function.visitor.EntityVisitor.resume(EntityVisitor.java:67) ~[?:?]
	at com.sk89q.worldedit.function.operation.OperationQueue.resume(OperationQueue.java:89) ~[?:?]
	at com.sk89q.worldedit.function.operation.DelegateOperation.resume(DelegateOperation.java:52) ~[?:?]
	at com.sk89q.worldedit.function.operation.Operations.completeLegacy(Operations.java:55) ~[?:?]
	at com.sk89q.worldedit.command.ClipboardCommands.paste(ClipboardCommands.java:162) ~[?:?]
	... 31 more
```