### PR TITLE
Minor improvements to Sponge implementation

### DIFF
--- a/worldedit-sponge/build.gradle
+++ b/worldedit-sponge/build.gradle
@@ -1,19 +1,20 @@
-apply plugin: 'eclipse'
-apply plugin: 'idea'
-
 buildscript {
     repositories {
         mavenCentral()
         maven { url = "http://files.minecraftforge.net/maven" }
-        maven { url = "http://repo.minecrell.net/snapshots" }
+        maven { url = "http://repo.minecrell.net/releases" }
         maven { url = "https://oss.sonatype.org/content/repositories/snapshots/" }
         jcenter()
     }
 
     dependencies {
-        classpath 'net.minecrell:VanillaGradle:2.0.3-SNAPSHOT'
+        classpath 'net.minecrell:VanillaGradle:2.0.3_1'
         classpath 'net.minecraftforge.gradle:ForgeGradle:2.1-SNAPSHOT'
     }
+}
+
+plugins {
+    id 'org.spongepowered.plugin' version '0.5.2'
 }
 
 apply plugin: 'net.minecrell.vanilla.server.library'
@@ -21,48 +22,30 @@ apply plugin: 'net.minecrell.vanilla.server.library'
 dependencies {
     compile project(':worldedit-core')
     compile 'org.spongepowered:spongeapi:4.1.0-SNAPSHOT'
-    compile 'ninja.leaping.configurate:configurate-hocon:3.1'
     testCompile group: 'org.mockito', name: 'mockito-core', version:'1.9.0-rc1'
-}
-
-repositories {
-    maven {
-        name = 'forge'
-        url = 'http://files.minecraftforge.net/maven'
-    }
-    maven {
-        name = "Sponge"
-        url = "https://repo.spongepowered.org/maven"
-    }
 }
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
+sponge {
+    plugin {
+        id = 'worldedit'
+    }
+}
+
 minecraft {
     version = "1.8.9"
     mappings = "stable_22"
     runDir = 'run'
-
-    replaceIn "com/sk89q/worldedit/sponge/SpongeWorldEdit.java"
-    replace "%VERSION%", project.version
 }
 
 project.archivesBaseName = "${project.archivesBaseName}-mc${minecraft.version}"
 
-processResources {
-    from (sourceSets.main.resources.srcDirs) {
-        expand 'version': project.version,
-                'mcVersion': project.minecraft.version,
-                'internalVersion': project.internalVersion
-    }
-}
-
 jar {
     manifest {
         attributes("Class-Path": "truezip.jar WorldEdit/truezip.jar js.jar WorldEdit/js.jar",
-                "WorldEdit-Version": version,
-                "FMLAT": "worldedit_at.cfg")
+                "WorldEdit-Version": version)
     }
 }
 

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/config/SpongeConfiguration.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/config/SpongeConfiguration.java
@@ -19,10 +19,12 @@
 
 package com.sk89q.worldedit.sponge.config;
 
+import com.google.inject.Inject;
 import com.sk89q.worldedit.sponge.SpongeWorldEdit;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
 import org.slf4j.Logger;
+import org.spongepowered.api.config.DefaultConfig;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,7 +34,8 @@ public class SpongeConfiguration extends ConfigurateConfiguration {
     public boolean creativeEnable = false;
     public boolean cheatMode = false;
 
-    public SpongeConfiguration(ConfigurationLoader<CommentedConfigurationNode> config, Logger logger) {
+    @Inject
+    public SpongeConfiguration(@DefaultConfig(sharedRoot = false) ConfigurationLoader<CommentedConfigurationNode> config, Logger logger) {
         super(config, logger);
     }
 


### PR DESCRIPTION
I made some minor improvements to the Gradle configuration and the main plugin class of the Sponge implementation that remove redundant parts (either because they're default or not needed for Sponge), or simplify the code:

- Use SpongeGradle for setting plugin version from Gradle
- Use Guice to manage configuration
- Use event filter annotation for interact event
- Set plugin description and URL
- Remove some redundant parts in the Gradle config