### PR TITLE
Allow for plugins/mods to register a clipboard format.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/jnbt/ListTag.java
+++ b/worldedit-core/src/main/java/com/sk89q/jnbt/ListTag.java
@@ -79,11 +79,10 @@ public final class ListTag extends Tag {
      */
     @Nullable
     public Tag getIfExists(int index) {
-        try {
-            return value.get(index);
-        } catch (NoSuchElementException e) {
+        if (index >= value.size()) {
             return null;
         }
+        return value.get(index);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -33,6 +33,7 @@ import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormats;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardReader;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardWriter;
 import com.sk89q.worldedit.function.operation.Operations;
@@ -101,7 +102,7 @@ public class SchematicCommands {
             return;
         }
 
-        ClipboardFormat format = ClipboardFormat.findByAlias(formatName);
+        ClipboardFormat format = ClipboardFormats.findByAlias(formatName);
         if (format == null) {
             player.printError("Unknown schematic format: " + formatName);
             return;
@@ -144,7 +145,7 @@ public class SchematicCommands {
         File dir = worldEdit.getWorkingDirectoryFile(config.saveDir);
         File f = worldEdit.getSafeSaveFile(player, dir, filename, "schematic", "schematic");
 
-        ClipboardFormat format = ClipboardFormat.findByAlias(formatName);
+        ClipboardFormat format = ClipboardFormats.findByAlias(formatName);
         if (format == null) {
             player.printError("Unknown schematic format: " + formatName);
             return;
@@ -232,9 +233,9 @@ public class SchematicCommands {
         actor.print("Available clipboard formats (Name: Lookup names)");
         StringBuilder builder;
         boolean first = true;
-        for (ClipboardFormat format : ClipboardFormat.values()) {
+        for (ClipboardFormat format : ClipboardFormats.getAll()) {
             builder = new StringBuilder();
-            builder.append(format.name()).append(": ");
+            builder.append(format.getName()).append(": ");
             for (String lookupName : format.getAliases()) {
                 if (!first) {
                     builder.append(", ");
@@ -342,10 +343,10 @@ public class SchematicCommands {
             StringBuilder build = new StringBuilder();
 
             build.append("\u00a72");
-            ClipboardFormat format = ClipboardFormat.findByFile(file);
+            ClipboardFormat format = ClipboardFormats.findByFile(file);
             boolean inRoot = file.getParentFile().getName().equals(prefix);
             build.append(inRoot ? file.getName() : file.getPath().split(Pattern.quote(prefix + File.separator))[1])
-                    .append(": ").append(format == null ? "Unknown" : format.name());
+                    .append(": ").append(format == null ? "Unknown" : format.getName());
             result.add(build.toString());
         }
         return result;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -112,7 +112,7 @@ public class SchematicCommands {
         try {
             FileInputStream fis = closer.register(new FileInputStream(f));
             BufferedInputStream bis = closer.register(new BufferedInputStream(fis));
-            ClipboardReader reader = format.getReader(bis);
+            ClipboardReader reader = closer.register(format.getReader(bis));
 
             WorldData worldData = player.getWorld().getWorldData();
             Clipboard clipboard = reader.read(player.getWorld().getWorldData());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -102,7 +102,11 @@ public class SchematicCommands {
             return;
         }
 
-        ClipboardFormat format = ClipboardFormats.findByAlias(formatName);
+        ClipboardFormat format = ClipboardFormats.findByFile(f);
+
+        if (format == null) {
+            format = ClipboardFormats.findByAlias(formatName);
+        }
         if (format == null) {
             player.printError("Unknown schematic format: " + formatName);
             return;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -95,7 +95,7 @@ public class SchematicCommands {
         LocalConfiguration config = worldEdit.getConfiguration();
 
         File dir = worldEdit.getWorkingDirectoryFile(config.saveDir);
-        File f = worldEdit.getSafeOpenFile(player, dir, filename, "schematic", "schematic");
+        File f = worldEdit.getSafeOpenFile(player, dir, filename, "schematic", ClipboardFormats.getFileExtensionArray());
 
         if (!f.exists()) {
             player.printError("Schematic " + filename + " does not exist!");
@@ -143,13 +143,14 @@ public class SchematicCommands {
         LocalConfiguration config = worldEdit.getConfiguration();
 
         File dir = worldEdit.getWorkingDirectoryFile(config.saveDir);
-        File f = worldEdit.getSafeSaveFile(player, dir, filename, "schematic", "schematic");
 
         ClipboardFormat format = ClipboardFormats.findByAlias(formatName);
         if (format == null) {
             player.printError("Unknown schematic format: " + formatName);
             return;
         }
+
+        File f = worldEdit.getSafeSaveFile(player, dir, filename, format.getPrimaryFileExtension());
 
         ClipboardHolder holder = session.getClipboard();
         Clipboard clipboard = holder.getClipboard();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormat.java
@@ -19,96 +19,23 @@
 
 package com.sk89q.worldedit.extent.clipboard.io;
 
-import com.sk89q.jnbt.NBTConstants;
-import com.sk89q.jnbt.NBTInputStream;
-import com.sk89q.jnbt.NBTOutputStream;
-
-import javax.annotation.Nullable;
-import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * A collection of supported clipboard formats.
+ * Represents a clipboard format. The format provides readers and writers for a
+ * Clipboard. Instances may be provided by WorldEdit or extensions.
  */
-public enum ClipboardFormat {
-
+public interface ClipboardFormat {
+    
     /**
-     * The Schematic format used by many software.
+     * Returns the name of this format.
+     * @return The name of the format
      */
-    SCHEMATIC("mcedit", "mce", "schematic") {
-        @Override
-        public ClipboardReader getReader(InputStream inputStream) throws IOException {
-            NBTInputStream nbtStream = new NBTInputStream(new GZIPInputStream(inputStream));
-            return new SchematicReader(nbtStream);
-        }
-
-        @Override
-        public ClipboardWriter getWriter(OutputStream outputStream) throws IOException {
-            NBTOutputStream nbtStream = new NBTOutputStream(new GZIPOutputStream(outputStream));
-            return new SchematicWriter(nbtStream);
-        }
-
-        @Override
-        public boolean isFormat(File file) {
-            DataInputStream str = null;
-            try {
-                str = new DataInputStream(new GZIPInputStream(new FileInputStream(file)));
-                if ((str.readByte() & 0xFF) != NBTConstants.TYPE_COMPOUND) {
-                    return false;
-                }
-                byte[] nameBytes = new byte[str.readShort() & 0xFFFF];
-                str.readFully(nameBytes);
-                String name = new String(nameBytes, NBTConstants.CHARSET);
-                return name.equals("Schematic");
-            } catch (IOException e) {
-                return false;
-            } finally {
-                if (str != null) {
-                    try {
-                        str.close();
-                    } catch (IOException ignored) {
-                    }
-                }
-            }
-        }
-    };
-
-    private static final Map<String, ClipboardFormat> aliasMap = new HashMap<String, ClipboardFormat>();
-
-    private final String[] aliases;
-
-    /**
-     * Create a new instance.
-     *
-     * @param aliases an array of aliases by which this format may be referred to
-     */
-    private ClipboardFormat(String ... aliases) {
-        this.aliases = aliases;
-    }
-
-    /**
-     * Get a set of aliases.
-     *
-     * @return a set of aliases
-     */
-    public Set<String> getAliases() {
-        return Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(aliases)));
-    }
+    String getName();
 
     /**
      * Create a reader.
@@ -117,7 +44,7 @@ public enum ClipboardFormat {
      * @return a reader
      * @throws IOException thrown on I/O error
      */
-    public abstract ClipboardReader getReader(InputStream inputStream) throws IOException;
+    ClipboardReader getReader(InputStream inputStream) throws IOException;
 
     /**
      * Create a writer.
@@ -126,7 +53,7 @@ public enum ClipboardFormat {
      * @return a writer
      * @throws IOException thrown on I/O error
      */
-    public abstract ClipboardWriter getWriter(OutputStream outputStream) throws IOException;
+    ClipboardWriter getWriter(OutputStream outputStream) throws IOException;
 
     /**
      * Return whether the given file is of this format.
@@ -134,45 +61,13 @@ public enum ClipboardFormat {
      * @param file the file
      * @return true if the given file is of this format
      */
-    public abstract boolean isFormat(File file);
-
-    static {
-        for (ClipboardFormat format : EnumSet.allOf(ClipboardFormat.class)) {
-            for (String key : format.aliases) {
-                aliasMap.put(key, format);
-            }
-        }
-    }
+    boolean isFormat(File file);
 
     /**
-     * Find the clipboard format named by the given alias.
+     * Get a set of aliases.
      *
-     * @param alias the alias
-     * @return the format, otherwise null if none is matched
+     * @return a set of aliases
      */
-    @Nullable
-    public static ClipboardFormat findByAlias(String alias) {
-        checkNotNull(alias);
-        return aliasMap.get(alias.toLowerCase().trim());
-    }
-
-    /**
-     * Detect the format given a file.
-     *
-     * @param file the file
-     * @return the format, otherwise null if one cannot be detected
-     */
-    @Nullable
-    public static ClipboardFormat findByFile(File file) {
-        checkNotNull(file);
-
-        for (ClipboardFormat format : EnumSet.allOf(ClipboardFormat.class)) {
-            if (format.isFormat(file)) {
-                return format;
-            }
-        }
-
-        return null;
-    }
+    Set<String> getAliases();
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormat.java
@@ -30,9 +30,10 @@ import java.util.Set;
  * Clipboard. Instances may be provided by WorldEdit or extensions.
  */
 public interface ClipboardFormat {
-    
+
     /**
      * Returns the name of this format.
+     *
      * @return The name of the format
      */
     String getName();
@@ -40,25 +41,30 @@ public interface ClipboardFormat {
     /**
      * Create a reader.
      *
-     * @param inputStream the input stream
+     * @param inputStream
+     *            the input stream
      * @return a reader
-     * @throws IOException thrown on I/O error
+     * @throws IOException
+     *             thrown on I/O error
      */
     ClipboardReader getReader(InputStream inputStream) throws IOException;
 
     /**
      * Create a writer.
      *
-     * @param outputStream the output stream
+     * @param outputStream
+     *            the output stream
      * @return a writer
-     * @throws IOException thrown on I/O error
+     * @throws IOException
+     *             thrown on I/O error
      */
     ClipboardWriter getWriter(OutputStream outputStream) throws IOException;
 
     /**
      * Return whether the given file is of this format.
      *
-     * @param file the file
+     * @param file
+     *            the file
      * @return true if the given file is of this format
      */
     boolean isFormat(File file);
@@ -69,5 +75,20 @@ public interface ClipboardFormat {
      * @return a set of aliases
      */
     Set<String> getAliases();
+
+    /**
+     * Get the file extension this format primarily uses.
+     *
+     * @return the primary file extension
+     */
+    String getPrimaryFileExtension();
+
+    /**
+     * Get the file extensions this format is commonly known to use. This should
+     * include {@link #getPrimaryFileExtension()}.
+     *
+     * @return the file extensions this format might be know by
+     */
+    Set<String> getFileExtensions();
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
@@ -1,0 +1,88 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.extent.clipboard.io;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public final class ClipboardFormats {
+
+    private static final Map<String, ClipboardFormat> aliasMap = new HashMap<>();
+    private static final List<ClipboardFormat> registeredFormats = new ArrayList<>();
+
+    public static void registerClipboardFormat(ClipboardFormat format) {
+        checkNotNull(format);
+
+        for (String key : format.getAliases()) {
+            aliasMap.put(key.toLowerCase(Locale.ENGLISH), format);
+        }
+        registeredFormats.add(format);
+    }
+
+    /**
+     * Find the clipboard format named by the given alias.
+     *
+     * @param alias
+     *            the alias
+     * @return the format, otherwise null if none is matched
+     */
+    @Nullable
+    public static ClipboardFormat findByAlias(String alias) {
+        checkNotNull(alias);
+        return aliasMap.get(alias.toLowerCase(Locale.ENGLISH).trim());
+    }
+
+    /**
+     * Detect the format of given a file.
+     *
+     * @param file
+     *            the file
+     * @return the format, otherwise null if one cannot be detected
+     */
+    @Nullable
+    public static ClipboardFormat findByFile(File file) {
+        checkNotNull(file);
+
+        for (ClipboardFormat format : registeredFormats) {
+            if (format.isFormat(file)) {
+                return format;
+            }
+        }
+
+        return null;
+    }
+
+    public static Collection<ClipboardFormat> getAll() {
+        return Collections.unmodifiableCollection(registeredFormats);
+    }
+
+    private ClipboardFormats() {
+    }
+
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
@@ -40,7 +40,12 @@ public final class ClipboardFormats {
         checkNotNull(format);
 
         for (String key : format.getAliases()) {
-            aliasMap.put(key.toLowerCase(Locale.ENGLISH), format);
+            String lowKey = key.toLowerCase(Locale.ENGLISH);
+            ClipboardFormat old = aliasMap.put(lowKey, format);
+            if (old != null) {
+                aliasMap.put(lowKey, old);
+                throw new IllegalArgumentException("Cannot override existing alias '" + lowKey + "' used by " + old.getClass().getName());
+            }
         }
         registeredFormats.add(format);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
@@ -19,6 +19,8 @@
 
 package com.sk89q.worldedit.extent.clipboard.io;
 
+import com.sk89q.worldedit.WorldEdit;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,7 +46,7 @@ public final class ClipboardFormats {
             ClipboardFormat old = aliasMap.put(lowKey, format);
             if (old != null) {
                 aliasMap.put(lowKey, old);
-                throw new IllegalArgumentException("Cannot override existing alias '" + lowKey + "' used by " + old.getClass().getName());
+                WorldEdit.logger.warning(format.getClass().getName() + " cannot override existing alias '" + lowKey + "' used by " + old.getClass().getName());
             }
         }
         registeredFormats.add(format);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardReader.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.extent.clipboard.io;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.world.registry.WorldData;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /**
@@ -29,7 +30,7 @@ import java.io.IOException;
  *
  * @see Clipboard
  */
-public interface ClipboardReader {
+public interface ClipboardReader extends Closeable {
 
     /**
      * Read a {@code Clipboard}.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReader.java
@@ -275,4 +275,9 @@ public class SchematicReader implements ClipboardReader {
         return expected.cast(test);
     }
 
+    @Override
+    public void close() throws IOException {
+        inputStream.close();
+    }
+
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SupportedClipboardFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SupportedClipboardFormat.java
@@ -1,0 +1,100 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.extent.clipboard.io;
+
+import com.google.common.collect.ImmutableSet;
+import com.sk89q.jnbt.NBTConstants;
+import com.sk89q.jnbt.NBTInputStream;
+import com.sk89q.jnbt.NBTOutputStream;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Set;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * A collection of supported clipboard formats.
+ */
+public enum SupportedClipboardFormat implements ClipboardFormat {
+
+    /**
+     * The Schematic format used by many software.
+     */
+    SCHEMATIC("mcedit", "mce", "schematic") {
+        @Override
+        public ClipboardReader getReader(InputStream inputStream) throws IOException {
+            NBTInputStream nbtStream = new NBTInputStream(new GZIPInputStream(inputStream));
+            return new SchematicReader(nbtStream);
+        }
+
+        @Override
+        public ClipboardWriter getWriter(OutputStream outputStream) throws IOException {
+            NBTOutputStream nbtStream = new NBTOutputStream(new GZIPOutputStream(outputStream));
+            return new SchematicWriter(nbtStream);
+        }
+
+        @Override
+        public boolean isFormat(File file) {
+            DataInputStream str = null;
+            try {
+                str = new DataInputStream(new GZIPInputStream(new FileInputStream(file)));
+                if ((str.readByte() & 0xFF) != NBTConstants.TYPE_COMPOUND) {
+                    return false;
+                }
+                byte[] nameBytes = new byte[str.readShort() & 0xFFFF];
+                str.readFully(nameBytes);
+                String name = new String(nameBytes, NBTConstants.CHARSET);
+                return name.equals("Schematic");
+            } catch (IOException e) {
+                return false;
+            } finally {
+                if (str != null) {
+                    try {
+                        str.close();
+                    } catch (IOException ignored) {
+                    }
+                }
+            }
+        }
+    };
+
+    private final ImmutableSet<String> aliases;
+
+    private SupportedClipboardFormat(String... aliases) {
+        this.aliases = ImmutableSet.copyOf(aliases);
+        ClipboardFormats.registerClipboardFormat(this);
+    }
+    
+    @Override
+    public String getName() {
+        return name();
+    }
+
+    @Override
+    public Set<String> getAliases() {
+        return this.aliases;
+    }
+
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SupportedClipboardFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SupportedClipboardFormat.java
@@ -43,6 +43,12 @@ public enum SupportedClipboardFormat implements ClipboardFormat {
      * The Schematic format used by many software.
      */
     SCHEMATIC("mcedit", "mce", "schematic") {
+
+        @Override
+        public String getPrimaryFileExtension() {
+            return "schematic";
+        }
+
         @Override
         public ClipboardReader getReader(InputStream inputStream) throws IOException {
             NBTInputStream nbtStream = new NBTInputStream(new GZIPInputStream(inputStream));
@@ -84,7 +90,6 @@ public enum SupportedClipboardFormat implements ClipboardFormat {
 
     private SupportedClipboardFormat(String... aliases) {
         this.aliases = ImmutableSet.copyOf(aliases);
-        ClipboardFormats.registerClipboardFormat(this);
     }
     
     @Override
@@ -95,6 +100,11 @@ public enum SupportedClipboardFormat implements ClipboardFormat {
     @Override
     public Set<String> getAliases() {
         return this.aliases;
+    }
+
+    @Override
+    public Set<String> getFileExtensions() {
+        return ImmutableSet.of(getPrimaryFileExtension());
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/schematic/MCEditSchematicFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/schematic/MCEditSchematicFormat.java
@@ -35,6 +35,7 @@ import com.sk89q.worldedit.CuboidClipboard;
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.blocks.BaseBlock;
 import com.sk89q.worldedit.data.DataException;
+import com.sk89q.worldedit.extent.clipboard.io.SupportedClipboardFormat;
 
 import java.io.DataInputStream;
 import java.io.File;
@@ -50,6 +51,10 @@ import java.util.Map.Entry;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+/**
+ * @deprecated Use {@link SupportedClipboardFormat#SCHEMATIC} instead.
+ */
+@Deprecated
 public class MCEditSchematicFormat extends SchematicFormat {
 
     private static final int MAX_SIZE = Short.MAX_VALUE - Short.MIN_VALUE;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/schematic/SchematicFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/schematic/SchematicFormat.java
@@ -22,16 +22,26 @@ package com.sk89q.worldedit.schematic;
 import com.sk89q.worldedit.CuboidClipboard;
 import com.sk89q.worldedit.blocks.BaseBlock;
 import com.sk89q.worldedit.data.DataException;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormats;
+import com.sk89q.worldedit.extent.clipboard.io.SupportedClipboardFormat;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
+/**
+ * @deprecated Use {@link ClipboardFormat} and {@link ClipboardFormats} instead.
+ */
+@Deprecated
 public abstract class SchematicFormat {
 
     private static final Map<String, SchematicFormat> SCHEMATIC_FORMATS = new HashMap<String, SchematicFormat>();
 
     // Built-in schematic formats
+    /**
+     * @deprecated Use {@link SupportedClipboardFormat#SCHEMATIC} instead.
+     */
     public static final SchematicFormat MCEDIT = new MCEditSchematicFormat();
 
     public static Set<SchematicFormat> getFormats() {


### PR DESCRIPTION
This change adds more flexibility to the ClipboardFormat system. It allows mods/plugins to register a format with WorldEdit for saving and loading. This change also allows to adopt Sponge's built-in schematic saver/loader (in a Sponge PR right now) if we want.

My main concern for this PR is that it breaks binary compatibility for `ClipboardFormat` by renaming the implementation to `SupportedClipboardFormat`. I think another solution may need to be considered, like deprecating the current `ClipboardFormat` and relocating them somewhere else.
