### PR TITLE
Fix region contain method

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CuboidRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CuboidRegion.java
@@ -329,16 +329,16 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
 
     @Override
     public boolean contains(Vector position) {
-        double x = position.getX();
-        double y = position.getY();
-        double z = position.getZ();
+        int x = position.getBlockX();
+        int y = position.getBlockY();
+        int z = position.getBlockZ();
 
         Vector min = getMinimumPoint();
         Vector max = getMaximumPoint();
 
-        return x >= min.getBlockX() && x < max.getBlockX() + 1
-                && y >= min.getBlockY() && y < max.getBlockY() + 1
-                && z >= min.getBlockZ() && z < max.getBlockZ() + 1;
+        return x >= min.getBlockX() && x <= max.getBlockX()
+                && y >= min.getBlockY() && y <= max.getBlockY()
+                && z >= min.getBlockZ() && z <= max.getBlockZ();
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CuboidRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CuboidRegion.java
@@ -336,9 +336,9 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
         Vector min = getMinimumPoint();
         Vector max = getMaximumPoint();
 
-        return x >= min.getBlockX() && x <= max.getBlockX()
-                && y >= min.getBlockY() && y <= max.getBlockY()
-                && z >= min.getBlockZ() && z <= max.getBlockZ();
+        return x >= min.getBlockX() && x < max.getBlockX() + 1
+                && y >= min.getBlockY() && y < max.getBlockY() + 1
+                && z >= min.getBlockZ() && z < max.getBlockZ() + 1;
     }
 
     @Override


### PR DESCRIPTION
The region contain method was broken.
A lot of subsquent issues are caused by this bug.
E.g. in a selection the entities in the last blocks at the positive-axis border are not selected.

`Max` block gives the impression of an exclusive point; however it is **inclusive**!
A position that is anywhere between of a 1x1x1 region, would return false in the old implementation.

By simply adding _1_ should solve the problem.

Greetings,
mike
