### PR TITLE
Vector and BlockVector should use the same hashCode

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/BlockVector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/BlockVector.java
@@ -85,13 +85,6 @@ public class BlockVector extends Vector {
     }
 
     @Override
-    public int hashCode() {
-        return ((int) x << 19) ^
-                ((int) y << 12) ^
-                (int) z;
-    }
-
-    @Override
     public BlockVector toBlockVector() {
         return this;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/BlockVector2D.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/BlockVector2D.java
@@ -81,12 +81,6 @@ public class BlockVector2D extends Vector2D {
     }
 
     @Override
-    public int hashCode() {
-        return (Integer.valueOf((int) x).hashCode() >> 13) ^
-                Integer.valueOf((int) z).hashCode();
-    }
-
-    @Override
     public BlockVector2D toBlockVector2D() {
         return this;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/Vector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/Vector.java
@@ -789,12 +789,7 @@ public class Vector implements Comparable<Vector> {
 
     @Override
     public int hashCode() {
-        int hash = 7;
-
-        hash = 79 * hash + (int) (Double.doubleToLongBits(this.x) ^ (Double.doubleToLongBits(this.x) >>> 32));
-        hash = 79 * hash + (int) (Double.doubleToLongBits(this.y) ^ (Double.doubleToLongBits(this.y) >>> 32));
-        hash = 79 * hash + (int) (Double.doubleToLongBits(this.z) ^ (Double.doubleToLongBits(this.z) >>> 32));
-        return hash;
+        return ((int) x ^ ((int) z << 12)) ^ ((int) y << 24);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/Vector2D.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/Vector2D.java
@@ -627,8 +627,7 @@ public class Vector2D {
 
     @Override
     public int hashCode() {
-        return ((new Double(x)).hashCode() >> 13) ^
-                (new Double(z)).hashCode();
+        return ((int) x << 16) ^ (int) z;
     }
 
     @Override


### PR DESCRIPTION
For example, the getChunks method returns a Set<Vector2D> which is actually comprised of BlockVector2D, so using set.contains(some vector) would always return false.

There's unlikely to be multiple entities on the same block, or above y=256, so using the int coords is better.