### PR TITLE
Improved block parsing

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/jnbt/JSON2NBT.java
+++ b/worldedit-core/src/main/java/com/sk89q/jnbt/JSON2NBT.java
@@ -1,0 +1,419 @@
+package com.sk89q.jnbt;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.sk89q.worldedit.extension.input.InputParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Stack;
+import java.util.regex.Pattern;
+
+public class JSON2NBT {
+    private static final Pattern INT_ARRAY_MATCHER = Pattern.compile("\\[[-+\\d|,\\s]+\\]");
+
+    private JSON2NBT() {
+    }
+
+    public static CompoundTag getTagFromJson(String jsonString) throws InputParseException {
+        jsonString = jsonString.trim();
+        if(!jsonString.startsWith("{")) {
+            throw new InputParseException("Invalid tag encountered, expected \'{\' as first char.");
+        } else if(topTagsCount(jsonString) != 1) {
+            throw new InputParseException("Encountered multiple top tags, only one expected");
+        } else {
+            return (CompoundTag)nameValueToNBT("tag", jsonString).parse();
+        }
+    }
+
+    public static int topTagsCount(String str) throws InputParseException {
+        int i = 0;
+        boolean flag = false;
+        Stack stack = new Stack();
+
+        for(int j = 0; j < str.length(); ++j) {
+            char c0 = str.charAt(j);
+            if(c0 == 34) {
+                if(isCharEscaped(str, j)) {
+                    if(!flag) {
+                        throw new InputParseException("Illegal use of \\\": " + str);
+                    }
+                } else {
+                    flag = !flag;
+                }
+            } else if(!flag) {
+                if(c0 != 123 && c0 != 91) {
+                    if(c0 == 125 && (stack.isEmpty() || ((Character)stack.pop()).charValue() != 123)) {
+                        throw new InputParseException("Unbalanced curly brackets {}: " + str);
+                    }
+
+                    if(c0 == 93 && (stack.isEmpty() || ((Character)stack.pop()).charValue() != 91)) {
+                        throw new InputParseException("Unbalanced square brackets []: " + str);
+                    }
+                } else {
+                    if(stack.isEmpty()) {
+                        ++i;
+                    }
+
+                    stack.push(Character.valueOf(c0));
+                }
+            }
+        }
+
+        if(flag) {
+            throw new InputParseException("Unbalanced quotation: " + str);
+        } else if(!stack.isEmpty()) {
+            throw new InputParseException("Unbalanced brackets: " + str);
+        } else {
+            if(i == 0 && !str.isEmpty()) {
+                i = 1;
+            }
+
+            return i;
+        }
+    }
+
+    private static JSON2NBT.Any joinStrToNBT(String... args) throws InputParseException {
+        return nameValueToNBT(args[0], args[1]);
+    }
+
+    private static JSON2NBT.Any nameValueToNBT(String key, String value) throws InputParseException {
+        value = value.trim();
+        String s;
+        boolean c0;
+        char c01;
+        if(value.startsWith("{")) {
+            value = value.substring(1, value.length() - 1);
+
+            JSON2NBT.Compound JSON2NBT$list1;
+            for(JSON2NBT$list1 = new JSON2NBT.Compound(key); value.length() > 0; value = value.substring(s.length() + 1)) {
+                s = nextNameValuePair(value, true);
+                if(s.length() > 0) {
+                    c0 = false;
+                    JSON2NBT$list1.tagList.add(getTagFromNameValue(s, false));
+                }
+
+                if(value.length() < s.length() + 1) {
+                    break;
+                }
+
+                c01 = value.charAt(s.length());
+                if(c01 != 44 && c01 != 123 && c01 != 125 && c01 != 91 && c01 != 93) {
+                    throw new InputParseException("Unexpected token \'" + c01 + "\' at: " + value.substring(s.length()));
+                }
+            }
+
+            return JSON2NBT$list1;
+        } else if(value.startsWith("[") && !INT_ARRAY_MATCHER.matcher(value).matches()) {
+            value = value.substring(1, value.length() - 1);
+
+            JSON2NBT.List JSON2NBT$list;
+            for(JSON2NBT$list = new JSON2NBT.List(key); value.length() > 0; value = value.substring(s.length() + 1)) {
+                s = nextNameValuePair(value, false);
+                if(s.length() > 0) {
+                    c0 = true;
+                    JSON2NBT$list.tagList.add(getTagFromNameValue(s, true));
+                }
+
+                if(value.length() < s.length() + 1) {
+                    break;
+                }
+
+                c01 = value.charAt(s.length());
+                if(c01 != 44 && c01 != 123 && c01 != 125 && c01 != 91 && c01 != 93) {
+                    throw new InputParseException("Unexpected token \'" + c01 + "\' at: " + value.substring(s.length()));
+                }
+            }
+
+            return JSON2NBT$list;
+        } else {
+            return new JSON2NBT.Primitive(key, value);
+        }
+    }
+
+    private static JSON2NBT.Any getTagFromNameValue(String str, boolean isArray) throws InputParseException {
+        String s = locateName(str, isArray);
+        String s1 = locateValue(str, isArray);
+        return joinStrToNBT(new String[]{s, s1});
+    }
+
+    private static String nextNameValuePair(String str, boolean isCompound) throws InputParseException {
+        int i = getNextCharIndex(str, ':');
+        int j = getNextCharIndex(str, ',');
+        if(isCompound) {
+            if(i == -1) {
+                throw new InputParseException("Unable to locate name/value separator for string: " + str);
+            }
+
+            if(j != -1 && j < i) {
+                throw new InputParseException("Name error at: " + str);
+            }
+        } else if(i == -1 || i > j) {
+            i = -1;
+        }
+
+        return locateValueAt(str, i);
+    }
+
+    private static String locateValueAt(String str, int index) throws InputParseException {
+        Stack stack = new Stack();
+        int i = index + 1;
+        boolean flag = false;
+        boolean flag1 = false;
+        boolean flag2 = false;
+
+        for(int j = 0; i < str.length(); ++i) {
+            char c0 = str.charAt(i);
+            if(c0 == 34) {
+                if(isCharEscaped(str, i)) {
+                    if(!flag) {
+                        throw new InputParseException("Illegal use of \\\": " + str);
+                    }
+                } else {
+                    flag = !flag;
+                    if(flag && !flag2) {
+                        flag1 = true;
+                    }
+
+                    if(!flag) {
+                        j = i;
+                    }
+                }
+            } else if(!flag) {
+                if(c0 != 123 && c0 != 91) {
+                    if(c0 == 125 && (stack.isEmpty() || ((Character)stack.pop()).charValue() != 123)) {
+                        throw new InputParseException("Unbalanced curly brackets {}: " + str);
+                    }
+
+                    if(c0 == 93 && (stack.isEmpty() || ((Character)stack.pop()).charValue() != 91)) {
+                        throw new InputParseException("Unbalanced square brackets []: " + str);
+                    }
+
+                    if(c0 == 44 && stack.isEmpty()) {
+                        return str.substring(0, i);
+                    }
+                } else {
+                    stack.push(Character.valueOf(c0));
+                }
+            }
+
+            if(!Character.isWhitespace(c0)) {
+                if(!flag && flag1 && j != i) {
+                    return str.substring(0, j + 1);
+                }
+
+                flag2 = true;
+            }
+        }
+
+        return str.substring(0, i);
+    }
+
+    private static String locateName(String str, boolean isArray) throws InputParseException {
+        if(isArray) {
+            str = str.trim();
+            if(str.startsWith("{") || str.startsWith("[")) {
+                return "";
+            }
+        }
+
+        int i = getNextCharIndex(str, ':');
+        if(i == -1) {
+            if(isArray) {
+                return "";
+            } else {
+                throw new InputParseException("Unable to locate name/value separator for string: " + str);
+            }
+        } else {
+            return str.substring(0, i).trim();
+        }
+    }
+
+    private static String locateValue(String str, boolean isArray) throws InputParseException {
+        if(isArray) {
+            str = str.trim();
+            if(str.startsWith("{") || str.startsWith("[")) {
+                return str;
+            }
+        }
+
+        int i = getNextCharIndex(str, ':');
+        if(i == -1) {
+            if(isArray) {
+                return str;
+            } else {
+                throw new InputParseException("Unable to locate name/value separator for string: " + str);
+            }
+        } else {
+            return str.substring(i + 1).trim();
+        }
+    }
+
+    private static int getNextCharIndex(String str, char targetChar) {
+        int i = 0;
+
+        for(boolean flag = true; i < str.length(); ++i) {
+            char c0 = str.charAt(i);
+            if(c0 == 34) {
+                if(!isCharEscaped(str, i)) {
+                    flag = !flag;
+                }
+            } else if(flag) {
+                if(c0 == targetChar) {
+                    return i;
+                }
+
+                if(c0 == 123 || c0 == 91) {
+                    return -1;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    private static boolean isCharEscaped(String str, int index) {
+        return index > 0 && str.charAt(index - 1) == 92 && !isCharEscaped(str, index - 1);
+    }
+
+    private static class Primitive extends JSON2NBT.Any {
+        private static final Pattern DOUBLE = Pattern.compile("[-+]?[0-9]*\\.?[0-9]+[d|D]");
+        private static final Pattern FLOAT = Pattern.compile("[-+]?[0-9]*\\.?[0-9]+[f|F]");
+        private static final Pattern BYTE = Pattern.compile("[-+]?[0-9]+[b|B]");
+        private static final Pattern LONG = Pattern.compile("[-+]?[0-9]+[l|L]");
+        private static final Pattern SHORT = Pattern.compile("[-+]?[0-9]+[s|S]");
+        private static final Pattern INTEGER = Pattern.compile("[-+]?[0-9]+");
+        private static final Pattern DOUBLE_UNTYPED = Pattern.compile("[-+]?[0-9]*\\.?[0-9]+");
+        private static final Splitter SPLITTER = Splitter.on(',').omitEmptyStrings();
+        protected String jsonValue;
+
+        public Primitive(String jsonIn, String valueIn) {
+            this.json = jsonIn;
+            this.jsonValue = valueIn;
+        }
+
+        public Tag parse() throws InputParseException {
+            try {
+                if(DOUBLE.matcher(this.jsonValue).matches()) {
+                    return new DoubleTag(Double.parseDouble(this.jsonValue.substring(0, this.jsonValue.length() - 1)));
+                }
+
+                if(FLOAT.matcher(this.jsonValue).matches()) {
+                    return new FloatTag(Float.parseFloat(this.jsonValue.substring(0, this.jsonValue.length() - 1)));
+                }
+
+                if(BYTE.matcher(this.jsonValue).matches()) {
+                    return new ByteTag(Byte.parseByte(this.jsonValue.substring(0, this.jsonValue.length() - 1)));
+                }
+
+                if(LONG.matcher(this.jsonValue).matches()) {
+                    return new LongTag(Long.parseLong(this.jsonValue.substring(0, this.jsonValue.length() - 1)));
+                }
+
+                if(SHORT.matcher(this.jsonValue).matches()) {
+                    return new ShortTag(Short.parseShort(this.jsonValue.substring(0, this.jsonValue.length() - 1)));
+                }
+
+                if(INTEGER.matcher(this.jsonValue).matches()) {
+                    return new IntTag(Integer.parseInt(this.jsonValue));
+                }
+
+                if(DOUBLE_UNTYPED.matcher(this.jsonValue).matches()) {
+                    return new DoubleTag(Double.parseDouble(this.jsonValue));
+                }
+
+                if("true".equalsIgnoreCase(this.jsonValue) || "false".equalsIgnoreCase(this.jsonValue)) {
+                    return new ByteTag((byte)(Boolean.parseBoolean(this.jsonValue)?1:0));
+                }
+            } catch (NumberFormatException var6) {
+                this.jsonValue = this.jsonValue.replaceAll("\\\\\"", "\"");
+                return new StringTag(this.jsonValue);
+            }
+
+            if(this.jsonValue.startsWith("[") && this.jsonValue.endsWith("]")) {
+                String var7 = this.jsonValue.substring(1, this.jsonValue.length() - 1);
+                String[] var8 = (String[])((String[]) Iterables.toArray(SPLITTER.split(var7), String.class));
+
+                try {
+                    int[] var5 = new int[var8.length];
+
+                    for(int j = 0; j < var8.length; ++j) {
+                        var5[j] = Integer.parseInt(var8[j].trim());
+                    }
+
+                    return new IntArrayTag(var5);
+                } catch (NumberFormatException var51) {
+                    return new StringTag(this.jsonValue);
+                }
+            } else {
+                if(this.jsonValue.startsWith("\"") && this.jsonValue.endsWith("\"")) {
+                    this.jsonValue = this.jsonValue.substring(1, this.jsonValue.length() - 1);
+                }
+
+                this.jsonValue = this.jsonValue.replaceAll("\\\\\"", "\"");
+                StringBuilder stringbuilder = new StringBuilder();
+
+                for(int i = 0; i < this.jsonValue.length(); ++i) {
+                    if(i < this.jsonValue.length() - 1 && this.jsonValue.charAt(i) == 92 && this.jsonValue.charAt(i + 1) == 92) {
+                        stringbuilder.append('\\');
+                        ++i;
+                    } else {
+                        stringbuilder.append(this.jsonValue.charAt(i));
+                    }
+                }
+
+                return new StringTag(stringbuilder.toString());
+            }
+        }
+    }
+
+    private static class List extends JSON2NBT.Any {
+        protected java.util.List<JSON2NBT.Any> tagList = Lists.newArrayList();
+
+        public List(String json) {
+            this.json = json;
+        }
+
+        public Tag parse() throws InputParseException {
+            ArrayList<Tag> list = new ArrayList();
+            Iterator var2 = this.tagList.iterator();
+
+            while(var2.hasNext()) {
+                JSON2NBT.Any JSON2NBT$any = (JSON2NBT.Any)var2.next();
+                list.add(JSON2NBT$any.parse());
+            }
+            Class<? extends Tag> tagType = list.isEmpty() ? CompoundTag.class : list.get(0).getClass();
+            return new ListTag(tagType, list);
+        }
+    }
+
+    private static class Compound extends JSON2NBT.Any {
+        protected java.util.List<JSON2NBT.Any> tagList = Lists.newArrayList();
+
+        public Compound(String jsonIn) {
+            this.json = jsonIn;
+        }
+
+        public Tag parse() throws InputParseException {
+            HashMap<String, Tag> map = new HashMap<String, Tag>();
+            Iterator var2 = this.tagList.iterator();
+
+            while(var2.hasNext()) {
+                JSON2NBT.Any JSON2NBT$any = (JSON2NBT.Any)var2.next();
+                map.put(JSON2NBT$any.json, JSON2NBT$any.parse());
+            }
+
+            return new CompoundTag(map);
+        }
+    }
+
+    private abstract static class Any {
+        protected String json;
+
+        Any() {
+        }
+
+        public abstract Tag parse() throws InputParseException;
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/DefaultBlockParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/DefaultBlockParser.java
@@ -19,8 +19,22 @@
 
 package com.sk89q.worldedit.extension.factory;
 
-import com.sk89q.worldedit.*;
-import com.sk89q.worldedit.blocks.*;
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.jnbt.JSON2NBT;
+import com.sk89q.jnbt.Tag;
+import com.sk89q.util.StringUtil;
+import com.sk89q.worldedit.BlockVector;
+import com.sk89q.worldedit.IncompleteRegionException;
+import com.sk89q.worldedit.NotABlockException;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.blocks.BaseBlock;
+import com.sk89q.worldedit.blocks.BlockType;
+import com.sk89q.worldedit.blocks.ClothColor;
+import com.sk89q.worldedit.blocks.MobSpawnerBlock;
+import com.sk89q.worldedit.blocks.NoteBlock;
+import com.sk89q.worldedit.blocks.SignBlock;
+import com.sk89q.worldedit.blocks.SkullBlock;
 import com.sk89q.worldedit.blocks.metadata.MobType;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.input.DisallowedUsageException;
@@ -29,14 +43,21 @@ import com.sk89q.worldedit.extension.input.NoMatchException;
 import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.internal.registry.InputParser;
+import com.sk89q.worldedit.math.MathUtils;
 import com.sk89q.worldedit.world.World;
+import com.sk89q.worldedit.world.registry.BundledBlockData;
+import com.sk89q.worldedit.world.registry.SimpleState;
+import com.sk89q.worldedit.world.registry.SimpleStateValue;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Parses block input strings.
  */
-class DefaultBlockParser extends InputParser<BaseBlock> {
+public class DefaultBlockParser extends InputParser<BaseBlock> {
 
-    protected DefaultBlockParser(WorldEdit worldEdit) {
+    public  DefaultBlockParser(WorldEdit worldEdit) {
         super(worldEdit);
     }
 
@@ -61,8 +82,8 @@ class DefaultBlockParser extends InputParser<BaseBlock> {
         // BlockType, as well as to properly handle mod:name IDs
 
         String originalInput = input;
-        input = input.replace("_", " ");
-        input = input.replace(";", "|");
+//        input = input.replace("_", " ");
+//        input = input.replace(";", "|");
         Exception suppressed = null;
         try {
             BaseBlock modified = parseLogic(input, context);
@@ -136,28 +157,33 @@ class DefaultBlockParser extends InputParser<BaseBlock> {
         } else {
             // Attempt to parse the item ID or otherwise resolve an item/block
             // name to its numeric ID
-            try {
+            if (MathUtils.isInteger(testId)) {
                 blockId = Integer.parseInt(testId);
                 blockType = BlockType.fromID(blockId);
-            } catch (NumberFormatException e) {
-                blockType = BlockType.lookup(testId);
-                if (blockType == null) {
-                    int t = worldEdit.getServer().resolveItem(testId);
-                    if (t >= 0) {
-                        blockType = BlockType.fromID(t); // Could be null
-                        blockId = t;
-                    } else if (blockLocator.length == 2) { // Block IDs in MC 1.7 and above use mod:name
-                        t = worldEdit.getServer().resolveItem(blockAndExtraData[0]);
+            } else {
+                BundledBlockData.BlockEntry block = BundledBlockData.getInstance().findById(testId);
+                if (block == null) {
+                    blockType = BlockType.lookup(testId);
+                    if (blockType == null) {
+                        int t = worldEdit.getServer().resolveItem(testId);
                         if (t >= 0) {
                             blockType = BlockType.fromID(t); // Could be null
                             blockId = t;
-                            typeAndData = new String[] { blockAndExtraData[0] };
-                            testId = blockAndExtraData[0];
+                        } else if (blockLocator.length == 2) { // Block IDs in MC 1.7 and above use mod:name
+                            t = worldEdit.getServer().resolveItem(blockAndExtraData[0]);
+                            if (t >= 0) {
+                                blockType = BlockType.fromID(t); // Could be null
+                                blockId = t;
+                                typeAndData = new String[] { blockAndExtraData[0] };
+                                testId = blockAndExtraData[0];
+                            }
                         }
                     }
+                } else {
+                    blockId = block.legacyId;
+                    blockType = BlockType.fromID(blockId);
                 }
             }
-
             if (blockId == -1 && blockType == null) {
                 // Maybe it's a cloth
                 ClothColor col = ClothColor.lookup(testId);
@@ -191,7 +217,25 @@ class DefaultBlockParser extends InputParser<BaseBlock> {
             // Parse the block data (optional)
             try {
                 if (typeAndData.length > 1 && !typeAndData[1].isEmpty()) {
-                    data = Integer.parseInt(typeAndData[1]);
+                    if (MathUtils.isInteger(typeAndData[1])) {
+                        data = Integer.parseInt(typeAndData[1]);
+                    } else {
+                        data = Integer.MAX_VALUE; // Some invalid value
+                        BundledBlockData.BlockEntry block = BundledBlockData.getInstance().findById(blockId);
+                        if (block != null && block.states != null) {
+                            loop:
+                            for (Map.Entry<String, SimpleState> stateEntry : block.states.entrySet()) {
+                                for (Map.Entry<String, SimpleStateValue> valueEntry : stateEntry.getValue().valueMap().entrySet()) {
+                                    String key = valueEntry.getKey();
+                                    if (key.equalsIgnoreCase(typeAndData[1])) {
+                                        data = valueEntry.getValue().data;
+                                        break loop;
+                                    }
+                                }
+
+                            }
+                        }
+                    }
                 }
 
                 if (data > 15) {
@@ -274,6 +318,21 @@ class DefaultBlockParser extends InputParser<BaseBlock> {
             return new BaseBlock(blockId, data);
         }
 
+        if (blockAndExtraData.length > 1 && blockAndExtraData[1].startsWith("{")) {
+            String joined = StringUtil.joinString(Arrays.copyOfRange(blockAndExtraData, 1, blockAndExtraData.length), "|");
+            try {
+                CompoundTag nbt = JSON2NBT.getTagFromJson(joined);
+                if (nbt != null) {
+                    if (context.isRestricted() && actor != null && !actor.hasPermission("worldedit.anyblock")) {
+                        throw new DisallowedUsageException("You are not allowed to nbt'");
+                    }
+                    return new BaseBlock(blockId, data, nbt);
+                }
+            } catch (InputParseException e) {
+                throw new NoMatchException(e.getMessage());
+            }
+        }
+
         switch (blockType) {
             case SIGN_POST:
             case WALL_SIGN:
@@ -284,7 +343,10 @@ class DefaultBlockParser extends InputParser<BaseBlock> {
                 text[2] = blockAndExtraData.length > 3 ? blockAndExtraData[3] : "";
                 text[3] = blockAndExtraData.length > 4 ? blockAndExtraData[4] : "";
                 return new SignBlock(blockType.getID(), data, text);
-
+            case CHEST:
+            case END_GATEWAY:
+            case END_PORTAL:
+                return new BaseBlock(blockId, data, new CompoundTag(new HashMap<String, Tag>()));
             case MOB_SPAWNER:
                 // Allow setting mob spawn type
                 if (blockAndExtraData.length > 1) {
@@ -356,5 +418,4 @@ class DefaultBlockParser extends InputParser<BaseBlock> {
                 return new BaseBlock(blockId, data);
         }
     }
-
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/DefaultBlockParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/DefaultBlockParser.java
@@ -163,21 +163,28 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
             } else {
                 BundledBlockData.BlockEntry block = BundledBlockData.getInstance().findById(testId);
                 if (block == null) {
-                    blockType = BlockType.lookup(testId);
-                    if (blockType == null) {
-                        int t = worldEdit.getServer().resolveItem(testId);
-                        if (t >= 0) {
-                            blockType = BlockType.fromID(t); // Could be null
-                            blockId = t;
-                        } else if (blockLocator.length == 2) { // Block IDs in MC 1.7 and above use mod:name
-                            t = worldEdit.getServer().resolveItem(blockAndExtraData[0]);
+                    BaseBlock baseBlock = BundledBlockData.getInstance().findByState(testId);
+                    if (baseBlock == null) {
+                        blockType = BlockType.lookup(testId);
+                        if (blockType == null) {
+                            int t = worldEdit.getServer().resolveItem(testId);
                             if (t >= 0) {
                                 blockType = BlockType.fromID(t); // Could be null
                                 blockId = t;
-                                typeAndData = new String[] { blockAndExtraData[0] };
-                                testId = blockAndExtraData[0];
+                            } else if (blockLocator.length == 2) { // Block IDs in MC 1.7 and above use mod:name
+                                t = worldEdit.getServer().resolveItem(blockAndExtraData[0]);
+                                if (t >= 0) {
+                                    blockType = BlockType.fromID(t); // Could be null
+                                    blockId = t;
+                                    typeAndData = new String[]{blockAndExtraData[0]};
+                                    testId = blockAndExtraData[0];
+                                }
                             }
                         }
+                    } else {
+                        blockId = baseBlock.getId();
+                        blockType = BlockType.fromID(blockId);
+                        data = baseBlock.getData();
                     }
                 } else {
                     blockId = block.legacyId;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/MathUtils.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/MathUtils.java
@@ -47,6 +47,30 @@ public final class MathUtils {
         return (int) (a - n * Math.floor(Math.floor(a) / n));
     }
 
+    public static final boolean isInteger(String str) {
+        if (str == null) {
+            return false;
+        }
+        int length = str.length();
+        if (length == 0) {
+            return false;
+        }
+        int i = 0;
+        if (str.charAt(0) == '-') {
+            if (length == 1) {
+                return false;
+            }
+            i = 1;
+        }
+        for (; i < length; i++) {
+            char c = str.charAt(i);
+            if ((c <= '/') || (c >= ':')) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /**
      * Returns the cosine of an angle given in degrees. This is better than
      * just {@code Math.cos(Math.toRadians(degrees))} because it provides a

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockData.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockData.java
@@ -97,7 +97,7 @@ public class BundledBlockData {
      * @return the entry, or null
      */
     @Nullable
-    private BlockEntry findById(String id) {
+    public BlockEntry findById(String id) {
         return idMap.get(id);
     }
 
@@ -108,7 +108,7 @@ public class BundledBlockData {
      * @return the entry, or null
      */
     @Nullable
-    private BlockEntry findById(int id) {
+    public BlockEntry findById(int id) {
         return legacyMap.get(id);
     }
 
@@ -169,13 +169,13 @@ public class BundledBlockData {
         return INSTANCE;
     }
 
-    private static class BlockEntry {
-        private int legacyId;
-        private String id;
-        private String unlocalizedName;
-        private List<String> aliases;
-        private Map<String, SimpleState> states = new HashMap<String, SimpleState>();
-        private SimpleBlockMaterial material = new SimpleBlockMaterial();
+    public static class BlockEntry {
+        public int legacyId;
+        public String id;
+        public String unlocalizedName;
+        public List<String> aliases;
+        public Map<String, SimpleState> states = new HashMap<String, SimpleState>();
+        public SimpleBlockMaterial material = new SimpleBlockMaterial();
 
         void postDeserialization() {
             for (SimpleState state : states.values()) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockData.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockData.java
@@ -24,10 +24,9 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.blocks.BaseBlock;
 import com.sk89q.worldedit.blocks.BlockMaterial;
 import com.sk89q.worldedit.util.gson.VectorAdapter;
-
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -36,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /**
  * Provides block data based on the built-in block database that is bundled
@@ -54,6 +54,7 @@ public class BundledBlockData {
     private static final BundledBlockData INSTANCE = new BundledBlockData();
 
     private final Map<String, BlockEntry> idMap = new HashMap<String, BlockEntry>();
+    private final Map<String, BaseBlock> stateMap = new HashMap<String, BaseBlock>();
     private final Map<Integer, BlockEntry> legacyMap = new HashMap<Integer, BlockEntry>(); // Trove usage removed temporarily
 
     /**
@@ -87,7 +88,27 @@ public class BundledBlockData {
             entry.postDeserialization();
             idMap.put(entry.id, entry);
             legacyMap.put(entry.legacyId, entry);
+            String id = (entry.id.contains(":") ? entry.id.split(":")[1] : entry.id).toLowerCase().replace(" ", "_");
+            if (!idMap.containsKey(id)) {
+                idMap.put(id, entry);
+            }
+            if (entry.states != null) {
+                for (Map.Entry<String, SimpleState> stateEntry : entry.states.entrySet()) {
+                    for (Map.Entry<String, SimpleStateValue> valueEntry : stateEntry.getValue().valueMap().entrySet()) {
+                        String key = valueEntry.getKey();
+                        if (!stateMap.containsKey(key)) {
+                            stateMap.put(key, new BaseBlock(entry.legacyId, valueEntry.getValue().data));
+                        }
+                    }
+
+                }
+
+            }
         }
+    }
+
+    public BaseBlock findByState(String state) {
+        return stateMap.get(state);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/SimpleState.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/SimpleState.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
 
-class SimpleState implements State {
+public class SimpleState implements State {
 
     private Byte dataMask;
     private Map<String, SimpleStateValue> values;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/SimpleStateValue.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/SimpleStateValue.java
@@ -22,11 +22,11 @@ package com.sk89q.worldedit.world.registry;
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.blocks.BaseBlock;
 
-class SimpleStateValue implements StateValue {
+public class SimpleStateValue implements StateValue {
 
-    private SimpleState state;
-    private Byte data;
-    private Vector direction;
+    public SimpleState state;
+    public Byte data;
+    public Vector direction;
 
     void setState(SimpleState state) {
         this.state = state;


### PR DESCRIPTION
Add NBT parsing (perm:`worldedit.anyblock`)
`//set banner|{your custom nbt}`

Use the BundledBlockData for parsing block names/states

The following additional syntaxes are supported:
`//set red` (red wool)
`//set andesite`
`//set stone:andesite`
`//set minecraft:stone:andesite`

It will default the the legacy BlockType + spell check if no result is found in the BundledBlockData