### PR TITLE
Exclude players and complex parts from region pastes

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitEntityType.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitEntityType.java
@@ -24,6 +24,7 @@ import com.sk89q.worldedit.util.Enums;
 import org.bukkit.entity.Ambient;
 import org.bukkit.entity.Animals;
 import org.bukkit.entity.Boat;
+import org.bukkit.entity.ComplexEntityPart;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.entity.FallingBlock;
@@ -34,6 +35,7 @@ import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Minecart;
 import org.bukkit.entity.Painting;
+import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.entity.Tameable;
@@ -57,6 +59,11 @@ class BukkitEntityType implements EntityType {
     @Override
     public boolean isPlayerDerived() {
         return entity instanceof HumanEntity;
+    }
+
+    @Override
+    public boolean isPlayer() {
+        return entity instanceof Player;
     }
 
     @Override
@@ -142,5 +149,10 @@ class BukkitEntityType implements EntityType {
     @Override
     public boolean isArmorStand() {
         return entity.getType() == armorStandType;
+    }
+
+    @Override
+    public boolean isComplexPart() {
+        return entity instanceof ComplexEntityPart;
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/entity/metadata/EntityType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/entity/metadata/EntityType.java
@@ -32,6 +32,13 @@ public interface EntityType {
     boolean isPlayerDerived();
 
     /**
+     * Test whether the entity is a player entity.
+     *
+     * @return true if a player entity
+     */
+    boolean isPlayer();
+
+    /**
      * Test whether the entity is a projectile.
      *
      * @return true if a projectile
@@ -154,4 +161,11 @@ public interface EntityType {
      * @return true if an armor stand
      */
     boolean isArmorStand();
+
+    /**
+     * Test whether the entity is a complex part.
+     *
+     * @return true if a complex part
+     */
+    boolean isComplexPart();
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/ForwardExtentCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/ForwardExtentCopy.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.function.operation;
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.entity.Entity;
+import com.sk89q.worldedit.entity.metadata.EntityType;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.function.CombinedRegionFunction;
 import com.sk89q.worldedit.function.RegionFunction;
@@ -36,6 +37,7 @@ import com.sk89q.worldedit.math.transform.Identity;
 import com.sk89q.worldedit.math.transform.Transform;
 import com.sk89q.worldedit.regions.Region;
 
+import java.util.Iterator;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -255,6 +257,14 @@ public class ForwardExtentCopy implements Operation {
                 ExtentEntityCopy entityCopy = new ExtentEntityCopy(from, destination, to, currentTransform);
                 entityCopy.setRemoving(removingEntities);
                 List<? extends Entity> entities = source.getEntities(region);
+                Iterator<? extends Entity> it = entities.iterator();
+                while (it.hasNext()) {
+                    EntityType type = it.next().getFacet(EntityType.class);
+                    // exclude players and complex parts from being copied
+                    if (type != null && (type.isPlayer() || type.isComplexPart())) {
+                        it.remove();
+                    }
+                }
                 EntityVisitor entityVisitor = new EntityVisitor(entities.iterator(), entityCopy);
                 return new DelegateOperation(this, new OperationQueue(blockVisitor, entityVisitor));
             } else {

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeEntityType.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeEntityType.java
@@ -25,6 +25,7 @@ import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.IMerchant;
 import net.minecraft.entity.INpc;
 import net.minecraft.entity.IProjectile;
+import net.minecraft.entity.boss.EntityDragonPart;
 import net.minecraft.entity.item.EntityArmorStand;
 import net.minecraft.entity.item.EntityBoat;
 import net.minecraft.entity.item.EntityEnderEye;
@@ -40,6 +41,7 @@ import net.minecraft.entity.passive.EntityAmbientCreature;
 import net.minecraft.entity.passive.EntityAnimal;
 import net.minecraft.entity.passive.EntityTameable;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -55,6 +57,11 @@ public class ForgeEntityType implements EntityType {
     @Override
     public boolean isPlayerDerived() {
         return entity instanceof EntityPlayer;
+    }
+
+    @Override
+    public boolean isPlayer() {
+        return entity instanceof EntityPlayerMP;
     }
 
     @Override
@@ -140,5 +147,10 @@ public class ForgeEntityType implements EntityType {
     @Override
     public boolean isArmorStand() {
         return entity instanceof EntityArmorStand;
+    }
+
+    @Override
+    public boolean isComplexPart() {
+        return entity instanceof EntityDragonPart;
     }
 }

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeEntityType.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeEntityType.java
@@ -30,7 +30,9 @@ import org.spongepowered.api.entity.hanging.ItemFrame;
 import org.spongepowered.api.entity.hanging.Painting;
 import org.spongepowered.api.entity.living.*;
 import org.spongepowered.api.entity.living.animal.Animal;
+import org.spongepowered.api.entity.living.complex.ComplexLivingPart;
 import org.spongepowered.api.entity.living.golem.Golem;
+import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.projectile.Projectile;
 import org.spongepowered.api.entity.vehicle.Boat;
 import org.spongepowered.api.entity.vehicle.minecart.Minecart;
@@ -53,6 +55,11 @@ public class SpongeEntityType implements EntityType {
     @Override
     public boolean isPlayerDerived() {
         return entity instanceof Humanoid;
+    }
+
+    @Override
+    public boolean isPlayer() {
+        return entity instanceof Player;
     }
 
     @Override
@@ -138,5 +145,10 @@ public class SpongeEntityType implements EntityType {
     @Override
     public boolean isArmorStand() {
         return entity instanceof ArmorStand;
+    }
+
+    @Override
+    public boolean isComplexPart() {
+        return entity instanceof ComplexLivingPart;
     }
 }


### PR DESCRIPTION
This PR adds a check to `ForwardExtentCopy` to block player and complex part entities from being pasted with a region. In addition to such behavior not making sense, it is also breaking on Sponge, which actively blocks spawning these entities.

This can be safely back-merged into `feature/sponge-5.1.0`, which does not function properly without this change (albeit with a merge conflict due to the entity-copying routine being wrapped in an if-block).