### PR TITLE
Add Support for Minecraft 1.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
     configurations.all {
         resolutionStrategy {
-            force 'com.google.guava:guava:17.0'
+            force 'com.google.guava:guava:21.0'
         }
     }
 

--- a/worldedit-core/build.gradle
+++ b/worldedit-core/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile 'de.schlichtherle:truezip:6.8.3'
     compile 'rhino:js:1.7R2'
     compile 'org.yaml:snakeyaml:1.9'
-    compile 'com.google.guava:guava:17.0'
+    compile 'com.google.guava:guava:21.0'
     compile 'com.sk89q:jchronic:0.2.4a'
     compile 'com.google.code.findbugs:jsr305:1.3.9'
     compile 'com.thoughtworks.paranamer:paranamer:2.6'

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/ReplaceParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/ReplaceParser.java
@@ -30,7 +30,7 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.util.command.argument.CommandArgs;
 import com.sk89q.worldedit.util.command.composition.SimpleCommand;
 
-import static com.google.common.base.Objects.firstNonNull;
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 public class ReplaceParser extends SimpleCommand<Contextual<? extends RegionFunction>> {
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Apply.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Apply.java
@@ -27,7 +27,7 @@ import com.sk89q.worldedit.function.visitor.RegionVisitor;
 import com.sk89q.worldedit.regions.NullRegion;
 import com.sk89q.worldedit.regions.Region;
 
-import static com.google.common.base.Objects.firstNonNull;
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class Apply implements Contextual<Operation> {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Deform.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Deform.java
@@ -19,7 +19,7 @@
 
 package com.sk89q.worldedit.function.factory;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.WorldEditException;
@@ -123,7 +123,7 @@ public class Deform implements Contextual<Operation> {
         final Vector zero;
         Vector unit;
 
-        Region region = Objects.firstNonNull(context.getRegion(), this.region);
+        Region region = MoreObjects.firstNonNull(context.getRegion(), this.region);
 
         switch (mode) {
             case UNIT_CUBE:

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Paint.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Paint.java
@@ -33,7 +33,7 @@ import com.sk89q.worldedit.math.noise.RandomNoise;
 import com.sk89q.worldedit.regions.NullRegion;
 import com.sk89q.worldedit.regions.Region;
 
-import static com.google.common.base.Objects.firstNonNull;
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.sk89q.worldedit.regions.Regions.*;
 


### PR DESCRIPTION
Minecraft 1.12 requires Java 8 and bundles Guava 21. This change allows usage in that scenario. Unfortunately it's hard/impossible to avoid breakage as Mojang jumped over two years of Guava versions, which is longer than their deprecation cycle.