### PR TITLE
updated guava + blocks.json

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
     configurations.all {
         resolutionStrategy {
-            force 'com.google.guava:guava:17.0'
+            force 'com.google.guava:guava:21.0'
         }
     }
 

--- a/worldedit-core/build.gradle
+++ b/worldedit-core/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile 'de.schlichtherle:truezip:6.8.3'
     compile 'rhino:js:1.7R2'
     compile 'org.yaml:snakeyaml:1.9'
-    compile 'com.google.guava:guava:17.0'
+    compile 'com.google.guava:guava:21.0'
     compile 'com.sk89q:jchronic:0.2.4a'
     compile 'com.google.code.findbugs:jsr305:1.3.9'
     compile 'com.thoughtworks.paranamer:paranamer:2.6'

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/ReplaceParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/ReplaceParser.java
@@ -30,7 +30,9 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.util.command.argument.CommandArgs;
 import com.sk89q.worldedit.util.command.composition.SimpleCommand;
 
-import static com.google.common.base.Objects.firstNonNull;
+
+import static com.sk89q.worldedit.util.command.argument.ArgumentUtils.firstNonNull;
+
 
 public class ReplaceParser extends SimpleCommand<Contextual<? extends RegionFunction>> {
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Apply.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Apply.java
@@ -27,8 +27,8 @@ import com.sk89q.worldedit.function.visitor.RegionVisitor;
 import com.sk89q.worldedit.regions.NullRegion;
 import com.sk89q.worldedit.regions.Region;
 
-import static com.google.common.base.Objects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.sk89q.worldedit.util.command.argument.ArgumentUtils.firstNonNull;
 
 public class Apply implements Contextual<Operation> {
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Deform.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Deform.java
@@ -19,7 +19,6 @@
 
 package com.sk89q.worldedit.function.factory;
 
-import com.google.common.base.Objects;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.WorldEditException;
@@ -36,6 +35,7 @@ import com.sk89q.worldedit.regions.Region;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.sk89q.worldedit.util.command.argument.ArgumentUtils.firstNonNull;
 
 public class Deform implements Contextual<Operation> {
 
@@ -123,7 +123,7 @@ public class Deform implements Contextual<Operation> {
         final Vector zero;
         Vector unit;
 
-        Region region = Objects.firstNonNull(context.getRegion(), this.region);
+        Region region = firstNonNull(context.getRegion(), this.region);
 
         switch (mode) {
             case UNIT_CUBE:

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Paint.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/factory/Paint.java
@@ -33,9 +33,9 @@ import com.sk89q.worldedit.math.noise.RandomNoise;
 import com.sk89q.worldedit.regions.NullRegion;
 import com.sk89q.worldedit.regions.Region;
 
-import static com.google.common.base.Objects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.sk89q.worldedit.regions.Regions.*;
+import static com.sk89q.worldedit.util.command.argument.ArgumentUtils.firstNonNull;
 
 public class Paint implements Contextual<Operation> {
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/command/argument/ArgumentUtils.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/command/argument/ArgumentUtils.java
@@ -20,9 +20,12 @@
 package com.sk89q.worldedit.util.command.argument;
 
 import com.google.common.collect.Lists;
-
 import java.util.Collection;
 import java.util.List;
+import javax.annotation.Nullable;
+
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class ArgumentUtils {
 
@@ -42,4 +45,7 @@ public final class ArgumentUtils {
         return suggestions;
     }
 
+    public static <T> T firstNonNull(@Nullable T first, @Nullable T second) {
+        return first != null ? first: checkNotNull(second);
+    }
 }

--- a/worldedit-core/src/main/resources/com/sk89q/worldedit/world/registry/blocks.json
+++ b/worldedit-core/src/main/resources/com/sk89q/worldedit/world/registry/blocks.json
@@ -10548,7 +10548,7 @@
     "legacyId": 159,
     "id": "minecraft:stained_hardened_clay",
     "unlocalizedName": "tile.clayHardenedStained",
-    "localizedName": "Stained Hardened Clay",
+    "localizedName": "Stained Terracotta",
     "states": {
       "color": {
         "dataMask": 15,
@@ -11556,7 +11556,7 @@
     "legacyId": 172,
     "id": "minecraft:hardened_clay",
     "unlocalizedName": "tile.clayHardened",
-    "localizedName": "Hardened Clay",
+    "localizedName": "Terracotta",
     "states": {},
     "material": {
       "powerSource": false,
@@ -16400,6 +16400,1280 @@
       "unpushable": false,
       "adventureModeExempt": false,
       "ambientOcclusionLightValue": 1.0,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 235,
+    "id": "minecraft:white_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaWhite",
+    "localizedName": "White Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 236,
+    "id": "minecraft:orange_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaOrange",
+    "localizedName": "Orange Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 237,
+    "id": "minecraft:magenta_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaMagenta",
+    "localizedName": "Magenta Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 238,
+    "id": "minecraft:light_blue_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaLightBlue",
+    "localizedName": "Light Blue Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 239,
+    "id": "minecraft:yellow_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaYellow",
+    "localizedName": "Yellow Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 240,
+    "id": "minecraft:lime_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaLime",
+    "localizedName": "Lime Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 241,
+    "id": "minecraft:pink_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaPink",
+    "localizedName": "Pink Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 242,
+    "id": "minecraft:gray_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaGray",
+    "localizedName": "Gray Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 243,
+    "id": "minecraft:silver_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaSilver",
+    "localizedName": "Light Gray Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 244,
+    "id": "minecraft:cyan_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaCyan",
+    "localizedName": "Cyan Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 245,
+    "id": "minecraft:purple_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaPurple",
+    "localizedName": "Purple Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 246,
+    "id": "minecraft:blue_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaBlue",
+    "localizedName": "Blue Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 247,
+    "id": "minecraft:brown_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaBrown",
+    "localizedName": "Brown Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 248,
+    "id": "minecraft:green_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaGreen",
+    "localizedName": "Green Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 249,
+    "id": "minecraft:red_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaRed",
+    "localizedName": "Red Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 250,
+    "id": "minecraft:black_glazed_terracotta",
+    "unlocalizedName": "tile.glazedTerracottaBlack",
+    "localizedName": "Black Glazed Terracotta",
+    "states": {
+      "facing": {
+        "dataMask": 3,
+        "values": {
+          "north": {
+            "data": 2,
+            "direction": [
+              0,
+              0,
+              -1
+            ]
+          },
+          "south": {
+            "data": 0,
+            "direction": [
+              0,
+              0,
+              1
+            ]
+          },
+          "west": {
+            "data": 1,
+            "direction": [
+              -1,
+              0,
+              0
+            ]
+          },
+          "east": {
+            "data": 3,
+            "direction": [
+              1,
+              0,
+              0
+            ]
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.4,
+      "resistance": 7.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 251,
+    "id": "minecraft:concrete",
+    "unlocalizedName": "tile.concrete",
+    "localizedName": "tile.concrete.name",
+    "states": {
+      "color": {
+        "dataMask": 15,
+        "values": {
+          "white": {
+            "data": 0
+          },
+          "orange": {
+            "data": 1
+          },
+          "magenta": {
+            "data": 2
+          },
+          "light_blue": {
+            "data": 3
+          },
+          "yellow": {
+            "data": 4
+          },
+          "lime": {
+            "data": 5
+          },
+          "pink": {
+            "data": 6
+          },
+          "gray": {
+            "data": 7
+          },
+          "silver": {
+            "data": 8
+          },
+          "cyan": {
+            "data": 9
+          },
+          "purple": {
+            "data": 10
+          },
+          "blue": {
+            "data": 11
+          },
+          "brown": {
+            "data": 12
+          },
+          "green": {
+            "data": 13
+          },
+          "red": {
+            "data": 14
+          },
+          "black": {
+            "data": 15
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 1.8,
+      "resistance": 9.0,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": true,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
+      "grassBlocking": false
+    }
+  },
+  {
+    "legacyId": 252,
+    "id": "minecraft:concrete_powder",
+    "unlocalizedName": "tile.concretePowder",
+    "localizedName": "tile.concretePowder.name",
+    "states": {
+      "color": {
+        "dataMask": 15,
+        "values": {
+          "white": {
+            "data": 0
+          },
+          "orange": {
+            "data": 1
+          },
+          "magenta": {
+            "data": 2
+          },
+          "light_blue": {
+            "data": 3
+          },
+          "yellow": {
+            "data": 4
+          },
+          "lime": {
+            "data": 5
+          },
+          "pink": {
+            "data": 6
+          },
+          "gray": {
+            "data": 7
+          },
+          "silver": {
+            "data": 8
+          },
+          "cyan": {
+            "data": 9
+          },
+          "purple": {
+            "data": 10
+          },
+          "blue": {
+            "data": 11
+          },
+          "brown": {
+            "data": 12
+          },
+          "green": {
+            "data": 13
+          },
+          "red": {
+            "data": 14
+          },
+          "black": {
+            "data": 15
+          }
+        }
+      }
+    },
+    "material": {
+      "powerSource": false,
+      "lightOpacity": 255,
+      "lightValue": 0,
+      "usingNeighborLight": false,
+      "hardness": 0.5,
+      "resistance": 2.5,
+      "ticksRandomly": false,
+      "fullCube": true,
+      "slipperiness": 0.6,
+      "renderedAsNormalBlock": true,
+      "liquid": false,
+      "solid": true,
+      "movementBlocker": true,
+      "burnable": false,
+      "opaque": true,
+      "replacedDuringPlacement": false,
+      "toolRequired": false,
+      "fragileWhenPushed": false,
+      "unpushable": false,
+      "adventureModeExempt": false,
+      "ambientOcclusionLightValue": 0.2,
       "grassBlocking": false
     }
   },


### PR DESCRIPTION
updated guava + blocks.json for 1.12]
This is backwards compatible and won't break the plugin for older versions