### PR TITLE
Add beds, concrete, and concrete powder to usesDamageValue hash

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/ItemType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/ItemType.java
@@ -757,6 +757,8 @@ public enum ItemType {
         usesDamageValue.add(BlockID.QUARTZ_BLOCK);
         usesDamageValue.add(BlockID.STAINED_CLAY);
         usesDamageValue.add(BlockID.CARPET);
+        usesDamageValue.add(BlockID.CONCRETE);
+        usesDamageValue.add(BlockID.CONCRETE_POWDER);
 
         usesDamageValue.add(ItemID.COAL);
         usesDamageValue.add(ItemID.INK_SACK);
@@ -767,6 +769,7 @@ public enum ItemType {
         usesDamageValue.add(ItemID.GOLD_APPLE);
         usesDamageValue.add(ItemID.RAW_FISH);
         usesDamageValue.add(ItemID.COOKED_FISH);
+        usesDamageValue.add(ItemID.BED_ITEM);
         usesDamageValue.add(ItemID.BANNER);
     }
 


### PR DESCRIPTION
Same issue as in #321. When running WorldGuard with the `protection.item-durability` configuration option set to `false`, breaking blocks while holding a bed, concrete block, or concrete powder will result in the item turning white (data value 0). Including them in this set prevents that from happening.