### PR TITLE
Fix FallbackRegistrationListener

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/bukkit/util/FallbackRegistrationListener.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/bukkit/util/FallbackRegistrationListener.java
@@ -34,7 +34,7 @@ public class FallbackRegistrationListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent event) {
-        if (commandRegistration.dispatch(event.getPlayer(), event.getMessage())) {
+        if (commandRegistration.dispatch(event.getPlayer(), event.getMessage().substring(1))) {
             event.setCancelled(true);
         }
     }


### PR DESCRIPTION
The FallbackRegistrationListener is used when Bukkit's SimpleCommandMap isn't present (or has been modified). e.g. Thermos, or if some plugin inserts a custom command map. 

Easiest way to replicate these conditions is to set the initial command map to null:
https://github.com/sk89q/WorldEdit/blob/master/worldedit-bukkit/src/main/java/com/sk89q/bukkit/util/CommandRegistration.java#L69