### PR TITLE
Make DinnerPermsResolver group prefix configurable

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/wepif/DinnerPermsResolver.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/wepif/DinnerPermsResolver.java
@@ -32,15 +32,27 @@ import java.util.List;
 
 public class DinnerPermsResolver implements PermissionsResolver {
 
+    // the default group prefix
     public static final String GROUP_PREFIX = "group.";
+
     protected final Server server;
+    protected final String groupPrefix;
+
+    public DinnerPermsResolver(Server server, String groupPrefix) {
+        this.server = server;
+        this.groupPrefix = groupPrefix;
+    }
+
+    public DinnerPermsResolver(Server server, YAMLProcessor config) {
+        this(server, config.getString("dinnerperms-group-prefix", GROUP_PREFIX));
+    }
 
     public DinnerPermsResolver(Server server) {
-        this.server = server;
+        this(server, GROUP_PREFIX);
     }
 
     public static PermissionsResolver factory(Server server, YAMLProcessor config) {
-        return new DinnerPermsResolver(server);
+        return new DinnerPermsResolver(server, config);
     }
 
     @Override
@@ -104,7 +116,7 @@ public class DinnerPermsResolver implements PermissionsResolver {
             return false;
         }
 
-        final String perm = GROUP_PREFIX + group;
+        final String perm = groupPrefix + group;
         return perms.isPermissionSet(perm) && perms.hasPermission(perm);
     }
 
@@ -117,10 +129,10 @@ public class DinnerPermsResolver implements PermissionsResolver {
         List<String> groupNames = new ArrayList<String>();
         for (PermissionAttachmentInfo permAttach : perms.getEffectivePermissions()) {
             String perm = permAttach.getPermission();
-            if (!(perm.startsWith(GROUP_PREFIX) && permAttach.getValue())) {
+            if (!(perm.startsWith(groupPrefix) && permAttach.getValue())) {
                 continue;
             }
-            groupNames.add(perm.substring(GROUP_PREFIX.length(), perm.length()));
+            groupNames.add(perm.substring(groupPrefix.length(), perm.length()));
         }
         return groupNames.toArray(new String[groupNames.size()]);
     }

--- a/worldedit-bukkit/src/main/java/com/sk89q/wepif/GroupManagerResolver.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/wepif/GroupManagerResolver.java
@@ -38,14 +38,14 @@ public class GroupManagerResolver extends DinnerPermsResolver {
                 return null;
             }
 
-            return new GroupManagerResolver(server, worldsHolder);
+            return new GroupManagerResolver(server, config, worldsHolder);
         } catch (Throwable t) {
             return null;
         }
     }
 
-    public GroupManagerResolver(Server server, WorldsHolder worldsHolder) {
-        super(server);
+    public GroupManagerResolver(Server server, YAMLProcessor config, WorldsHolder worldsHolder) {
+        super(server, config);
         this.worldsHolder = worldsHolder;
     }
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/wepif/PermissionsExResolver.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/wepif/PermissionsExResolver.java
@@ -37,14 +37,14 @@ public class PermissionsExResolver extends DinnerPermsResolver {
                 return null;
             }
 
-            return new PermissionsExResolver(server, manager);
+            return new PermissionsExResolver(server, config, manager);
         } catch (Throwable t) {
             return null;
         }
     }
 
-    public PermissionsExResolver(Server server, PermissionManager manager) {
-        super(server);
+    public PermissionsExResolver(Server server, YAMLProcessor config, PermissionManager manager) {
+        super(server, config);
         this.manager = manager;
     }
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/wepif/PermissionsResolverManager.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/wepif/PermissionsResolverManager.java
@@ -211,6 +211,11 @@ public class PermissionsResolverManager implements PermissionsResolver {
             isUpdated = true;
         }
 
+        if (!keys.contains("dinnerperms-group-prefix")) {
+            config.setProperty("dinnerperms-group-prefix", DinnerPermsResolver.GROUP_PREFIX);
+            isUpdated = true;
+        }
+
         if (!keys.contains("resolvers")) {
             //List<String> resolverKeys = config.getKeys("resolvers");
             List<String> resolvers = new ArrayList<String>();


### PR DESCRIPTION
Allows you to adapt the DinnerPerms resolver to lookup group memberships using an alternative node prefix.

Not all permission plugins implement the `group.<name>` format - and on the other hand, using that format for stuff like WorldGuard regions can create conflicts with other usages of the default `group.` format.

The current format is still used by default.