### PR TITLE
Calculation Config missing and typo [bugfix/timed-calc]

### DIFF
--- a/worldedit-bukkit/src/main/resources/defaults/config.yml
+++ b/worldedit-bukkit/src/main/resources/defaults/config.yml
@@ -12,7 +12,7 @@
 # - If you want to check the format of this file before putting it
 #   into WorldEdit, paste it into http://yaml-online-parser.appspot.com/
 #   and see if it gives "ERROR:".
-# - Lines starting with # are commentsand so they are ignored.
+# - Lines starting with # are comments, so they are ignored.
 #
 
 limits:
@@ -64,6 +64,9 @@ files:
 history:
     size: 15
     expiration: 10
+    
+calculation:
+    timeout: 100
 
 wand-item: 271
 shell-save-type:


### PR DESCRIPTION
Added missing configuration option as its not generated when you reset the config in the bugfix/timed-calc branch, plus also fixed a typo in the comments on top of the configuration file. 