### PR TITLE
Fix //snow doesn't put snow on all types of leaves

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1656,7 +1656,10 @@ public class EditSession implements Extent {
 
                     // Snow should not cover these blocks
                     if (BlockType.isTranslucent(id)) {
-                        break;
+                        // Add snow on leaves
+                        if (id != BlockID.LEAVES && id != BlockID.LEAVES) {
+                            break;
+                        }
                     }
 
                     // Too high?

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/BlockType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/BlockType.java
@@ -1346,6 +1346,7 @@ public enum BlockType {
         isTranslucent.add(BlockID.BARRIER);
         isTranslucent.add(BlockID.IRON_TRAP_DOOR);
         isTranslucent.add(BlockID.CARPET);
+        isTranslucent.add(BlockID.LEAVES2);
         isTranslucent.add(BlockID.STAINED_GLASS_PANE);
         isTranslucent.add(BlockID.DOUBLE_PLANT);
         isTranslucent.add(BlockID.STANDING_BANNER);


### PR DESCRIPTION
For example, //snow didn't work on Oak leaves while it did work as you would expect on Dark Oak leaves. Fixed by adding leaves2 to translucent block list and checking if the block to put snow on is a leaf block when executing //snow.