### PR TITLE
Fix loading and converting signs in old schematics

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/SignCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/SignCompatibilityHandler.java
@@ -23,6 +23,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSyntaxException;
 import com.sk89q.jnbt.StringTag;
 import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.blocks.BaseBlock;
@@ -43,7 +44,17 @@ public class SignCompatibilityHandler implements NBTCompatibilityHandler {
             Tag value = values.get(key);
             if (value instanceof StringTag) {
                 String storedString = ((StringTag) value).getValue();
-                JsonElement jsonElement = new JsonParser().parse(storedString);
+                JsonElement jsonElement = null;
+                if (storedString != null && storedString.startsWith("{")) {
+                    try {
+                        jsonElement = new JsonParser().parse(storedString);
+                    } catch (JsonSyntaxException ex) {
+                        // ignore: jsonElement will be null in the next check
+                    }
+                }
+                if (jsonElement == null) {
+                    jsonElement = new JsonPrimitive(storedString == null ? "" : storedString);
+                }
                 if (jsonElement.isJsonObject()) {
                     continue;
                 }


### PR DESCRIPTION
Fixes https://dev.enginehub.org/youtrack/issue/WORLDEDIT-3642

* Sign texts not starting with { are never valid json objects, so don't try to parse
* Else try to parse as json, but fall back to read sign text as string if not parseable