### PR TITLE
Add date in worldedit.log

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/logging/LogFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/logging/LogFormat.java
@@ -20,10 +20,13 @@
 package com.sk89q.worldedit.util.logging;
 
 import java.util.logging.Formatter;
+
 import java.util.logging.LogRecord;
 import java.util.logging.Level;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+
+import java.util.Date;
 
 /**
  * A standard logging format for WorldEdit.
@@ -33,6 +36,9 @@ public class LogFormat extends Formatter {
     public String format(LogRecord record) {
         StringBuilder text = new StringBuilder();
         Level level = record.getLevel();
+        
+        Date today = new Date();
+        text.append("[" + today + "] ");
 
         if (level == Level.FINEST) {
             text.append("[FINEST] ");


### PR DESCRIPTION
Hi,

Recently, i've see that my server save all commands worldedit in worldedit.log but there are no date or hours, so i've edit the code to add this function. Could you merge it with the base project ?

Thank's
Fabien