### PR TITLE
Added customizable command log format + Fixed entities double transformation

### DIFF
--- a/worldedit-bukkit/src/main/resources/defaults/config.yml
+++ b/worldedit-bukkit/src/main/resources/defaults/config.yml
@@ -40,6 +40,17 @@ use-inventory:
 logging:
     log-commands: false
     file: worldedit.log
+    # The format of custom log message. This is java general format string (java.util.Formatter). Arguments are:
+    #   1$ : date - a Date object representing event time of the log record.
+    #   2$ : source - a string representing the caller, if available; otherwise, the logger's name.
+    #   3$ : logger - the logger's name.
+    #   4$ : level - the log level.
+    #   5$ : message - the formatted log message returned from the Formatter.formatMessage(LogRecord) method. It uses java.text formatting and does not use the java.util.Formatter format argument.
+    #   6$ : thrown - a string representing the throwable associated with the log record and its backtrace beginning with a newline character, if any; otherwise, an empty string.
+    # For details see:
+    #   https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html
+    #   https://docs.oracle.com/javase/8/docs/api/java/util/logging/SimpleFormatter.html#format-java.util.logging.LogRecord-
+    format: "[%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s]: %5$s%6$s%n"
 
 super-pickaxe:
     drop-items: true

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalConfiguration.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalConfiguration.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit;
 
 import com.sk89q.worldedit.blocks.BlockID;
 import com.sk89q.worldedit.blocks.ItemID;
+import com.sk89q.worldedit.util.logging.LogFormat;
 import com.sk89q.worldedit.world.snapshot.SnapshotRepository;
 
 import java.io.File;
@@ -92,6 +93,7 @@ public abstract class LocalConfiguration {
     public int maxBrushRadius = 6;
     public boolean logCommands = false;
     public String logFile = "";
+    public String logFormat = LogFormat.DEFAULT_FORMAT;
     public boolean registerHelp = true; // what is the point of this, it's not even used
     public int wandItem = ItemID.WOOD_AXE;
     public boolean superPickaxeDrop = true;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/CommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/CommandManager.java
@@ -96,7 +96,6 @@ public final class CommandManager {
 
         // Setup the logger
         commandLog.addHandler(dynamicHandler);
-        dynamicHandler.setFormatter(new LogFormat());
 
         // Set up the commands manager
         ParametricBuilder builder = new ParametricBuilder();
@@ -185,6 +184,8 @@ public final class CommandManager {
             } catch (IOException e) {
                 log.log(Level.WARNING, "Could not use command log file " + path + ": " + e.getMessage());
             }
+
+            dynamicHandler.setFormatter(new LogFormat(platformManager.getConfiguration().logFormat));
         }
 
         platform.registerCommands(dispatcher);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/ForwardExtentCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/ForwardExtentCopy.java
@@ -250,9 +250,7 @@ public class ForwardExtentCopy implements Operation {
             RegionFunction function = sourceFunction != null ? new CombinedRegionFunction(filter, sourceFunction) : filter;
             RegionVisitor blockVisitor = new RegionVisitor(region, function);
 
-            lastVisitor = blockVisitor;
-            currentTransform = currentTransform.combine(transform);
-
+            Operation operation = blockVisitor;
             if (copyingEntities) {
                 ExtentEntityCopy entityCopy = new ExtentEntityCopy(from, destination, to, currentTransform);
                 entityCopy.setRemoving(removingEntities);
@@ -267,10 +265,13 @@ public class ForwardExtentCopy implements Operation {
                     }
                 }
                 EntityVisitor entityVisitor = new EntityVisitor(entities.iterator(), entityCopy);
-                return new DelegateOperation(this, new OperationQueue(blockVisitor, entityVisitor));
-            } else {
-                return new DelegateOperation(this, blockVisitor);
+                operation = new DelegateOperation(this, new OperationQueue(blockVisitor, entityVisitor));
             }
+
+            lastVisitor = blockVisitor;
+            currentTransform = currentTransform.combine(transform);
+
+            return new DelegateOperation(this, operation);
         } else {
             return null;
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/PropertiesConfiguration.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/PropertiesConfiguration.java
@@ -95,6 +95,7 @@ public class PropertiesConfiguration extends LocalConfiguration {
         maxBrushRadius = getInt("max-brush-radius", maxBrushRadius);
         logCommands = getBool("log-commands", logCommands);
         logFile = getString("log-file", logFile);
+        logFormat = getString("log-format", logFormat);
         registerHelp = getBool("register-help", registerHelp);
         wandItem = getInt("wand-item", wandItem);
         superPickaxeDrop = getBool("super-pickaxe-drop-items", superPickaxeDrop);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/YAMLConfiguration.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/YAMLConfiguration.java
@@ -82,6 +82,7 @@ public class YAMLConfiguration extends LocalConfiguration {
         registerHelp = config.getBoolean("register-help", true);
         logCommands = config.getBoolean("logging.log-commands", logCommands);
         logFile = config.getString("logging.file", logFile);
+        logFormat = config.getString("logging.format", logFormat);
 
         superPickaxeDrop = config.getBoolean("super-pickaxe.drop-items",
                 superPickaxeDrop);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/logging/LogFormat.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/logging/LogFormat.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.util.logging;
 
+import java.util.Date;
 import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
 import java.util.logging.Level;
@@ -29,35 +30,56 @@ import java.io.StringWriter;
  * A standard logging format for WorldEdit.
  */
 public class LogFormat extends Formatter {
+    public static final String DEFAULT_FORMAT = "[%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s]: %5$s%6$s%n";
+    private final Date dat = new Date();
+    private final String format;
+
+    public LogFormat() {
+        this(null);
+    }
+
+    public LogFormat(String format) {
+        System.out.println(format);
+        if (format == null || format.isEmpty()) {
+            format = DEFAULT_FORMAT;
+        }
+        try {
+            //noinspection ResultOfMethodCallIgnored
+            String.format(format, new Date(), "", "", "", "", "");
+        } catch (IllegalArgumentException var3) {
+            format = DEFAULT_FORMAT;
+        }
+        this.format = format;
+    }
+
     @Override
     public String format(LogRecord record) {
-        StringBuilder text = new StringBuilder();
-        Level level = record.getLevel();
-
-        if (level == Level.FINEST) {
-            text.append("[FINEST] ");
-        } else if (level == Level.FINER) {
-            text.append("[FINER] ");
-        } else if (level == Level.FINE) {
-            text.append("[FINE] ");
-        } else if (level == Level.INFO) {
-            text.append("[INFO] ");
-        } else if (level == Level.WARNING) {
-            text.append("[WARNING] ");
-        } else if (level == Level.SEVERE) {
-            text.append("[SEVERE] ");
+        dat.setTime(record.getMillis());
+        String source;
+        if (record.getSourceClassName() != null) {
+            source = record.getSourceClassName();
+            if (record.getSourceMethodName() != null) {
+                source += " " + record.getSourceMethodName();
+            }
+        } else {
+            source = record.getLoggerName();
         }
-
-        text.append(record.getMessage());
-        text.append("\r\n");
-
-        Throwable t = record.getThrown();
-        if (t != null) {
-            StringWriter writer = new StringWriter();
-            t.printStackTrace(new PrintWriter(writer));
-            text.append(writer);
+        String message = formatMessage(record);
+        String throwable = "";
+        if (record.getThrown() != null) {
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            pw.println();
+            record.getThrown().printStackTrace(pw);
+            pw.close();
+            throwable = sw.toString();
         }
-
-        return text.toString();
+        return String.format(format,
+                dat,
+                source,
+                record.getLoggerName(),
+                record.getLevel().getName(),
+                message,
+                throwable);
     }
 }

--- a/worldedit-forge/src/main/resources/defaults/worldedit.properties
+++ b/worldedit-forge/src/main/resources/defaults/worldedit.properties
@@ -18,6 +18,7 @@ scripting-timeout=3000
 snapshots-dir=
 use-inventory-creative-override=false
 log-file=worldedit.log
+log-format=[%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s]: %5$s%6$s%n
 max-changed-blocks=-1
 nav-wand-distance=50
 butcher-default-radius=-1

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/config/ConfigurateConfiguration.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/config/ConfigurateConfiguration.java
@@ -86,6 +86,7 @@ public class ConfigurateConfiguration extends LocalConfiguration {
         registerHelp = node.getNode("register-help").getBoolean(true);
         logCommands = node.getNode("logging", "log-commands").getBoolean(logCommands);
         logFile = node.getNode("logging", "file").getString(logFile);
+        logFormat = node.getNode("logging", "format").getString(logFormat);
 
         superPickaxeDrop = node.getNode("super-pickaxe", "drop-items").getBoolean(superPickaxeDrop);
         superPickaxeManyDrop = node.getNode("super-pickaxe", "many-drop-items").getBoolean(superPickaxeManyDrop);


### PR DESCRIPTION
**Added customizable command log format (Date+Time are now available)**:
Added the option "format" to config files (config.yml + worldedit.properties). By default, current date and time are also displayed.
The formatting function is implemented by analogy with the class java.util.logging.SimpleFormatter
_Notes: I also added comments in default config.yml. I'm not sure that this option and description will be understandable for most users, but it allows you to customize the format of the command log_ =\

**Fixed entities double transformation:**
The bug was in command //paste after command //rotate <angle>.
Entities in clipboard were rotated by 2*<angle> during paste command
_Notes: This is a new version of https://github.com/sk89q/WorldEdit/pull/412. I am still does not understand why we need to remember double tranformation after paste blocks_ =\

PS. I'm sorry that I included two commits in one query, but I do not know how to do it separately


