### PR TITLE
Fix entities double transformation copy-rotate-paste and stack

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/ForwardExtentCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/ForwardExtentCopy.java
@@ -243,6 +243,8 @@ public class ForwardExtentCopy implements Operation {
 
             if (currentTransform == null) {
                 currentTransform = transform;
+            } else {
+                currentTransform = currentTransform.combine(transform);
             }
 
             ExtentBlockCopy blockCopy = new ExtentBlockCopy(source, from, destination, to, currentTransform);
@@ -251,7 +253,6 @@ public class ForwardExtentCopy implements Operation {
             RegionVisitor blockVisitor = new RegionVisitor(region, function);
 
             lastVisitor = blockVisitor;
-            currentTransform = currentTransform.combine(transform);
 
             if (copyingEntities) {
                 ExtentEntityCopy entityCopy = new ExtentEntityCopy(from, destination, to, currentTransform);


### PR DESCRIPTION
The bug was during command //paste after command //rotate angle.
Entities in clipboard were rotated by 2*angle during paste command
Also, the bug was during command //stack n
Selected region was copied n-times with shift, but entities were shifted one region more

**Tested with commands stack,copy,rotate,paste**
1. //stack 3 up (checked field "repetitions")
2. //copy -e //rotate 45 //rotate 45 //paste (checked transformation)
