### PR TITLE
Fix ascent and descent commands.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/NavigationCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/NavigationCommands.java
@@ -75,9 +75,12 @@ public class NavigationCommands {
     )
     @CommandPermissions("worldedit.navigation.ascend")
     public void ascend(Player player, @Optional("1") int levelsToAscend) throws WorldEditException {
-        int ascentLevels = 1;
-        while (player.ascendLevel() && levelsToAscend != ascentLevels) {
+        int ascentLevels = 0;
+        while (player.ascendLevel()) {
             ++ascentLevels;
+            if (levelsToAscend == ascentLevels) {
+                break;
+            }
         }
         if (ascentLevels == 0) {
             player.printError("No free spot above you found.");
@@ -95,12 +98,15 @@ public class NavigationCommands {
     )
     @CommandPermissions("worldedit.navigation.descend")
     public void descend(Player player, @Optional("1") int levelsToDescend) throws WorldEditException {
-        int descentLevels = 1;
-        while (player.descendLevel() && levelsToDescend != descentLevels) {
+        int descentLevels = 0;
+        while (player.descendLevel()) {
             ++descentLevels;
+            if (levelsToDescend == descentLevels) {
+                break;
+            }
         }
         if (descentLevels == 0) {
-            player.printError("No free spot above you found.");
+            player.printError("No free spot below you found.");
         } else {
             player.print((descentLevels != 1) ? "Descended " + Integer.toString(descentLevels) + " levels." : "Descended a level.");
         }


### PR DESCRIPTION
For seven years and two days, the algorithm for ascent and descent has had an off-by-one error, and started at the wrong level.
Also, the message for failed descent has apparently never been right.
I figured I'd follow Java's conventions (as I see them) and have a body for the loop, so instead of incrementing the counter within the loop condition, I refactored the loop and put in a break statement.  I prefer the shorter version, but POLA wins in a foreign code base.

I tested this on my server and it seems to work fine.