### PR TITLE
Fix plugin enabling on Bukkit without compatible adapter

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -82,11 +82,10 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
 
         WorldEdit worldEdit = WorldEdit.getInstance();
 
-        loadAdapter(); // Need an adapter to work with special blocks with NBT data
-
         // Setup platform
         server = new BukkitServerInterface(this, getServer());
         worldEdit.getPlatformManager().register(server);
+        loadAdapter(); // Need an adapter to work with special blocks with NBT data
         worldEdit.loadMappings();
 
         loadConfig(); // Load configuration


### PR DESCRIPTION
When loading WorldEdit on a Bukkit server which it does not have an adapter for, a stacktrace is printed to console and WorldEdit does not load. This commit fixes that by registering the BukkitServerInterface before attempting to find a matching adapter.