### PR TITLE
Issue while copying a build with 1.13 blocks in 1.13.1

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -37,6 +37,7 @@ import com.sk89q.worldedit.extent.reorder.MultiStageReorder;
 import com.sk89q.worldedit.extent.validation.BlockChangeLimiter;
 import com.sk89q.worldedit.extent.validation.DataValidatorExtent;
 import com.sk89q.worldedit.extent.world.BlockQuirkExtent;
+import com.sk89q.worldedit.extent.world.ChunkBatchingModeExtent;
 import com.sk89q.worldedit.extent.world.ChunkLoadingExtent;
 import com.sk89q.worldedit.extent.world.FastModeExtent;
 import com.sk89q.worldedit.extent.world.SurvivalModeExtent;
@@ -115,6 +116,7 @@ public class EditSession implements Extent {
     private final ChangeSet changeSet = new BlockOptimizedHistory();
 
     private @Nullable FastModeExtent fastModeExtent;
+    private @Nullable ChunkBatchingModeExtent chunkBatchingModeExtent;
     private final SurvivalModeExtent survivalExtent;
     private @Nullable ChunkLoadingExtent chunkLoadingExtent;
     private @Nullable LastAccessExtentCache cacheExtent;
@@ -183,6 +185,7 @@ public class EditSession implements Extent {
             extent = survivalExtent = new SurvivalModeExtent(extent, world);
             extent = quirkExtent = new BlockQuirkExtent(extent, world);
             extent = chunkLoadingExtent = new ChunkLoadingExtent(extent, world);
+            extent = chunkBatchingModeExtent = new ChunkBatchingModeExtent(extent, world, false);
             extent = cacheExtent = new LastAccessExtentCache(extent);
             extent = wrapExtent(extent, eventBus, event, Stage.BEFORE_CHANGE);
             extent = validator = new DataValidatorExtent(extent, world);
@@ -343,6 +346,34 @@ public class EditSession implements Extent {
         if (fastModeExtent != null) {
             fastModeExtent.setEnabled(enabled);
         }
+    }
+
+    /**
+     * Set whether chunk batching mode is enabled.
+     *
+     * <p>Chunk batching mode will group changes and accesses
+     * into the chunks they touch in an attempt to speed up
+     * actions.</p>
+     *
+     * @param enabled true to enable
+     */
+    public void setChunkBatchingMode(boolean enabled) {
+        if (chunkBatchingModeExtent != null) {
+            chunkBatchingModeExtent.setEnabled(enabled);
+        }
+    }
+
+    /**
+     * Return chunk batching mode status.
+     *
+     * <p>Chunk batching mode will group changes and accesses
+     * into the chunks they touch in an attempt to speed up
+     * actions.</p>
+     *
+     * @return true if enabled
+     */
+    public boolean hasChunkBatchingMode() {
+        return chunkBatchingModeExtent != null && chunkBatchingModeExtent.isEnabled();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -82,6 +82,7 @@ public class LocalSession {
     private transient boolean hasCUISupport = false;
     private transient int cuiVersion = -1;
     private transient boolean fastMode = false;
+    private transient boolean chunkBatchingMode = false;
     private transient Mask mask;
     private transient TimeZone timezone = TimeZone.getDefault();
 
@@ -866,6 +867,7 @@ public class LocalSession {
                 .getEditSession(player.isPlayer() ? player.getWorld() : null,
                         getBlockChangeLimit(), blockBag, player);
         editSession.setFastMode(fastMode);
+        editSession.setChunkBatchingMode(chunkBatchingMode);
         Request.request().setEditSession(editSession);
         editSession.setMask(mask);
 
@@ -888,6 +890,25 @@ public class LocalSession {
      */
     public void setFastMode(boolean fastMode) {
         this.fastMode = fastMode;
+    }
+
+
+    /**
+     * Checks if the session has chunk batching mode enabled.
+     *
+     * @return true if chunk batching mode is enabled
+     */
+    public boolean hasChunkBatchingMode() {
+        return chunkBatchingMode;
+    }
+
+    /**
+     * Set chunk batching mode.
+     *
+     * @param fastMode true if chunk batching mode is enabled
+     */
+    public void setChunkBatchingMode(boolean chunkBatchingMode) {
+        this.chunkBatchingMode = chunkBatchingMode;
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GeneralCommands.java
@@ -109,6 +109,36 @@ public class GeneralCommands {
     }
 
     @Command(
+        aliases = { "/chunkbatch" },
+        usage = "[on|off]",
+        desc = "Toggle chunk batching mode",
+        min = 0,
+        max = 1
+    )
+    @CommandPermissions("worldedit.chunkbatch")
+    public void chunkbatch(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException {
+
+        String newState = args.getString(0, null);
+        if (session.hasChunkBatchingMode()) {
+            if ("on".equals(newState)) {
+                player.printError("Chunk batching mode already enabled.");
+                return;
+            }
+
+            session.setChunkBatchingMode(false);
+            player.print("Chunk batching mode disabled.");
+        } else {
+            if ("off".equals(newState)) {
+                player.printError("Chunk batching mode already disabled.");
+                return;
+            }
+
+            session.setChunkBatchingMode(true);
+            player.print("Chunk batching mode enabled. Beta feature, block placement order may be incorrect but actions should run quicker.");
+        }
+    }
+
+    @Command(
         aliases = { "/gmask", "gmask" },
         usage = "[mask]",
         desc = "Set the global mask",

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/ChunkBatchingModeExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/ChunkBatchingModeExtent.java
@@ -1,0 +1,125 @@
+package com.sk89q.worldedit.extent.world;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.sk89q.worldedit.BlockVector;
+import com.sk89q.worldedit.BlockVector2D;
+import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.blocks.BaseBlock;
+import com.sk89q.worldedit.extent.AbstractDelegateExtent;
+import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.function.operation.Operation;
+import com.sk89q.worldedit.function.operation.RunContext;
+import com.sk89q.worldedit.history.change.BlockChange;
+import com.sk89q.worldedit.world.World;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ChunkBatchingModeExtent extends AbstractDelegateExtent {
+
+    private static BlockVector2D chunkLocation(Vector location) {
+        return new BlockVector2D(location.getBlockX() >> 4,
+                location.getBlockZ() >> 4);
+    }
+
+    // TODO: we can totally write a more efficient version of this
+    // i.e. without a new BlockVector2D per block being set/retrieved
+    private final Multimap<BlockVector2D, BlockChange> chunkChanges =
+            HashMultimap.create();
+    private final World world;
+    private boolean enabled = true;
+
+    /**
+     * Create a new instance with fast mode enabled.
+     *
+     * @param delegate
+     *            - the extent to delegate to
+     * @param world
+     *            - the world
+     */
+    public ChunkBatchingModeExtent(Extent delegate, World world) {
+        this(delegate, world, true);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param delegate
+     *            - the extent to delegate to
+     * @param world
+     *            - the world
+     * @param enabled
+     *            - true to enable fast mode
+     */
+    public ChunkBatchingModeExtent(Extent delegate, World world, boolean enabled) {
+        super(delegate);
+        checkNotNull(world);
+        this.world = world;
+        this.enabled = enabled;
+    }
+
+    /**
+     * Return whether chunk batching mode is enabled.
+     *
+     * @return true if chunk batching mode is enabled
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Set chunk batching mode enable status.
+     *
+     * @param enabled
+     *            - true to enable chunk batching mode
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public boolean setBlock(Vector location, BaseBlock block)
+            throws WorldEditException {
+        if (enabled) {
+            // Assume it is in position and will be set.
+            return this.chunkChanges.put(chunkLocation(location),
+                    new BlockChange(new BlockVector(location), block, block));
+        } else {
+            return super.setBlock(location, block);
+        }
+    }
+
+    @Override
+    protected Operation commitBefore() {
+        return new Operation() {
+            
+            @Override
+            public Operation resume(RunContext run) throws WorldEditException {
+                BlockVector2D minimumChunk = chunkLocation(getMinimumPoint());
+                BlockVector2D maximumChunk = chunkLocation(getMaximumPoint());
+                for (int z = minimumChunk.getBlockZ(); z < maximumChunk.getBlockZ(); z++) {
+                    for (int x = minimumChunk.getBlockX(); x < maximumChunk.getBlockX(); x++) {
+                        BlockVector2D chunkPos = new BlockVector2D(x, z);
+                        world.checkLoadedChunk(chunkPos.toVector());
+                        for (BlockChange change : chunkChanges.get(chunkPos)) {
+                            getExtent().setBlock(change.getPosition(), change.getCurrent());
+                        }
+                    }
+                }
+                return null;
+            }
+            
+            @Override
+            public void cancel() {
+            }
+            
+            @Override
+            public void addStatusMessages(List<String> messages) {
+            }
+        };
+    }
+
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/ChunkBatchingModeExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/ChunkBatchingModeExtent.java
@@ -78,6 +78,9 @@ public class ChunkBatchingModeExtent extends AbstractDelegateExtent {
      */
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+        if (!enabled) {
+            this.chunkChanges.clear();
+        }
     }
 
     @Override
@@ -98,6 +101,9 @@ public class ChunkBatchingModeExtent extends AbstractDelegateExtent {
             
             @Override
             public Operation resume(RunContext run) throws WorldEditException {
+                if (chunkChanges.isEmpty()) {
+                    return null;
+                }
                 BlockVector2D minimumChunk = chunkLocation(getMinimumPoint());
                 BlockVector2D maximumChunk = chunkLocation(getMaximumPoint());
                 for (int z = minimumChunk.getBlockZ(); z < maximumChunk.getBlockZ(); z++) {
@@ -109,6 +115,7 @@ public class ChunkBatchingModeExtent extends AbstractDelegateExtent {
                         }
                     }
                 }
+                chunkChanges.clear();
                 return null;
             }
             


### PR DESCRIPTION
[16:40:32 INFO]: SpinyGames issued server command: //copy
[16:40:32 WARN]: com.sk89q.worldedit.extension.input.NoMatchException: Does not match a valid block type: 'minecraft:dead_tube_coral[waterlogged=false]'
[16:40:32 WARN]:        at com.sk89q.worldedit.extension.factory.DefaultBlockParser.parseLogic(DefaultBlockParser.java:263)
[16:40:32 WARN]:        at com.sk89q.worldedit.extension.factory.DefaultBlockParser.parseFromInput(DefaultBlockParser.java:90)
[16:40:32 WARN]:        at com.sk89q.worldedit.extension.factory.DefaultBlockParser.parseFromInput(DefaultBlockParser.java:55)
[16:40:32 WARN]:        at com.sk89q.worldedit.internal.registry.AbstractFactory.parseFromInput(AbstractFactory.java:57)
[16:40:32 WARN]:        at com.sk89q.worldedit.bukkit.BukkitAdapter$1.apply(BukkitAdapter.java:339)
[16:40:32 WARN]:        at com.sk89q.worldedit.bukkit.BukkitAdapter$1.apply(BukkitAdapter.java:334)
[16:40:32 WARN]:        at java.util.HashMap.computeIfAbsent(Unknown Source)
[16:40:32 WARN]:        at com.sk89q.worldedit.bukkit.BukkitAdapter.adapt(BukkitAdapter.java:334)
[16:40:32 WARN]:        at com.sk89q.worldedit.bukkit.adapter.impl.Spigot_v1_13_R2.getBlock(Spigot_v1_13_R2.java:230)
[16:40:32 WARN]:        at com.sk89q.worldedit.bukkit.BukkitWorld.getFullBlock(BukkitWorld.java:444)
[16:40:32 WARN]:        at com.sk89q.worldedit.EditSession.getFullBlock(EditSession.java:409)
[16:40:32 WARN]:        at com.sk89q.worldedit.function.block.ExtentBlockCopy.apply(ExtentBlockCopy.java:71)
[16:40:32 WARN]:        at com.sk89q.worldedit.function.RegionMaskingFilter.apply(RegionMaskingFilter.java:53)
[16:40:32 WARN]:        at com.sk89q.worldedit.function.visitor.RegionVisitor.resume(RegionVisitor.java:57)
[16:40:32 WARN]:        at com.sk89q.worldedit.function.operation.DelegateOperation.resume(DelegateOperation.java:52)
[16:40:32 WARN]:        at com.sk89q.worldedit.function.operation.Operations.completeLegacy(Operations.java:55)
[16:40:32 WARN]:        at com.sk89q.worldedit.command.ClipboardCommands.copy(ClipboardCommands.java:94)
[16:40:32 WARN]:        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[16:40:32 WARN]:        at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
[16:40:32 WARN]:        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
[16:40:32 WARN]:        at java.lang.reflect.Method.invoke(Unknown Source)
[16:40:32 WARN]:        at com.sk89q.worldedit.util.command.parametric.ParametricCallable.call(ParametricCallable.java:243)
[16:40:32 WARN]:        at com.sk89q.worldedit.util.command.SimpleDispatcher.call(SimpleDispatcher.java:125)
[16:40:32 WARN]:        at com.sk89q.worldedit.extension.platform.CommandManager.handleCommand(CommandManager.java:275)
[16:40:32 WARN]:        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[16:40:32 WARN]:        at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
[16:40:32 WARN]:        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
[16:40:32 WARN]:        at java.lang.reflect.Method.invoke(Unknown Source)
[16:40:32 WARN]:        at com.sk89q.worldedit.util.eventbus.MethodEventHandler.dispatch(MethodEventHandler.java:58)
[16:40:32 WARN]:        at com.sk89q.worldedit.util.eventbus.EventHandler.handleEvent(EventHandler.java:73)
[16:40:32 WARN]:        at com.sk89q.worldedit.util.eventbus.EventBus.dispatch(EventBus.java:187)
[16:40:32 WARN]:        at com.sk89q.worldedit.util.eventbus.EventBus.post(EventBus.java:173)
[16:40:32 WARN]:        at com.sk89q.worldedit.bukkit.WorldEditPlugin.onCommand(WorldEditPlugin.java:231)
[16:40:32 WARN]:        at com.sk89q.bukkit.util.DynamicPluginCommand.execute(DynamicPluginCommand.java:54)
[16:40:32 WARN]:        at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:151)
[16:40:32 WARN]:        at org.bukkit.craftbukkit.v1_13_R2.CraftServer.dispatchCommand(CraftServer.java:726)
[16:40:32 WARN]:        at net.minecraft.server.v1_13_R2.PlayerConnection.handleCommand(PlayerConnection.java:1770)
[16:40:32 WARN]:        at net.minecraft.server.v1_13_R2.PlayerConnection.a(PlayerConnection.java:1574)
[16:40:32 WARN]:        at net.minecraft.server.v1_13_R2.PacketPlayInChat.a(PacketPlayInChat.java:45)
[16:40:32 WARN]:        at net.minecraft.server.v1_13_R2.PacketPlayInChat.a(PacketPlayInChat.java:5)
[16:40:32 WARN]:        at net.minecraft.server.v1_13_R2.PlayerConnectionUtils.lambda$ensureMainThread$0(PlayerConnectionUtils.java:12)
[16:40:32 WARN]:        at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
[16:40:32 WARN]:        at java.util.concurrent.FutureTask.run(Unknown Source)
[16:40:32 WARN]:        at net.minecraft.server.v1_13_R2.SystemUtils.a(SourceFile:199)
[16:40:32 WARN]:        at net.minecraft.server.v1_13_R2.MinecraftServer.b(MinecraftServer.java:1016)
[16:40:32 WARN]:        at net.minecraft.server.v1_13_R2.DedicatedServer.b(DedicatedServer.java:434)
[16:40:32 WARN]:        at net.minecraft.server.v1_13_R2.MinecraftServer.a(MinecraftServer.java:943)
[16:40:32 WARN]:        at net.minecraft.server.v1_13_R2.MinecraftServer.run(MinecraftServer.java:841)
[16:40:32 WARN]:        at java.lang.Thread.run(Unknown Source)
[16:40:32 WARN]:        Suppressed: com.sk89q.worldedit.extension.input.NoMatchException: Does not match a valid block type: 'minecraft:dead_tube_coral[waterlogged=false]'
[16:40:32 WARN]:                at com.sk89q.worldedit.extension.factory.DefaultBlockParser.parseLogic(DefaultBlockParser.java:263)
[16:40:32 WARN]:                at com.sk89q.worldedit.extension.factory.DefaultBlockParser.parseFromInput(DefaultBlockParser.java:82)
[16:40:32 WARN]:                ... 47 more
[16:40:32 ERROR]: [WorldEdit] An unexpected error while handling a WorldEdit command
java.lang.reflect.InvocationTargetException: null
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_181]
        at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_181]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_181]
        at java.lang.reflect.Method.invoke(Unknown Source) ~[?:1.8.0_181]
        at com.sk89q.worldedit.util.command.parametric.ParametricCallable.call(ParametricCallable.java:243) ~[?:?]
        at com.sk89q.worldedit.util.command.SimpleDispatcher.call(SimpleDispatcher.java:125) ~[?:?]
        at com.sk89q.worldedit.extension.platform.CommandManager.handleCommand(CommandManager.java:275) ~[?:?]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_181]
        at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_181]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_181]
        at java.lang.reflect.Method.invoke(Unknown Source) ~[?:1.8.0_181]
        at com.sk89q.worldedit.util.eventbus.MethodEventHandler.dispatch(MethodEventHandler.java:58) ~[?:?]
        at com.sk89q.worldedit.util.eventbus.EventHandler.handleEvent(EventHandler.java:73) ~[?:?]
        at com.sk89q.worldedit.util.eventbus.EventBus.dispatch(EventBus.java:187) ~[?:?]
        at com.sk89q.worldedit.util.eventbus.EventBus.post(EventBus.java:173) ~[?:?]
        at com.sk89q.worldedit.bukkit.WorldEditPlugin.onCommand(WorldEditPlugin.java:231) ~[?:?]
        at com.sk89q.bukkit.util.DynamicPluginCommand.execute(DynamicPluginCommand.java:54) ~[?:?]
        at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:151) ~[patched_1.13.1.jar:git-Paper-"d33d3306"]
        at org.bukkit.craftbukkit.v1_13_R2.CraftServer.dispatchCommand(CraftServer.java:726) ~[patched_1.13.1.jar:git-Paper-"d33d3306"]
        at net.minecraft.server.v1_13_R2.PlayerConnection.handleCommand(PlayerConnection.java:1770) ~[patched_1.13.1.jar:git-Paper-"d33d3306"]
        at net.minecraft.server.v1_13_R2.PlayerConnection.a(PlayerConnection.java:1574) ~[patched_1.13.1.jar:git-Paper-"d33d3306"]
        at net.minecraft.server.v1_13_R2.PacketPlayInChat.a(PacketPlayInChat.java:45) ~[patched_1.13.1.jar:git-Paper-"d33d3306"]
        at net.minecraft.server.v1_13_R2.PacketPlayInChat.a(PacketPlayInChat.java:5) ~[patched_1.13.1.jar:git-Paper-"d33d3306"]
        at net.minecraft.server.v1_13_R2.PlayerConnectionUtils.lambda$ensureMainThread$0(PlayerConnectionUtils.java:12) ~[patched_1.13.1.jar:git-Paper-"d33d3306"]
        at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[?:1.8.0_181]
        at java.util.concurrent.FutureTask.run(Unknown Source) ~[?:1.8.0_181]
        at net.minecraft.server.v1_13_R2.SystemUtils.a(SourceFile:199) ~[patched_1.13.1.jar:git-Paper-"d33d3306"]
        at net.minecraft.server.v1_13_R2.MinecraftServer.b(MinecraftServer.java:1016) ~[patched_1.13.1.jar:git-Paper-"d33d3306"]
        at net.minecraft.server.v1_13_R2.DedicatedServer.b(DedicatedServer.java:434) ~[patched_1.13.1.jar:git-Paper-"d33d3306"]
        at net.minecraft.server.v1_13_R2.MinecraftServer.a(MinecraftServer.java:943) ~[patched_1.13.1.jar:git-Paper-"d33d3306"]
        at net.minecraft.server.v1_13_R2.MinecraftServer.run(MinecraftServer.java:841) ~[patched_1.13.1.jar:git-Paper-"d33d3306"]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_181]
Caused by: java.lang.NullPointerException
        at com.sk89q.worldedit.bukkit.adapter.impl.Spigot_v1_13_R2.getBlock(Spigot_v1_13_R2.java:240) ~[?:?]
        at com.sk89q.worldedit.bukkit.BukkitWorld.getFullBlock(BukkitWorld.java:444) ~[?:?]
        at com.sk89q.worldedit.EditSession.getFullBlock(EditSession.java:409) ~[?:?]
        at com.sk89q.worldedit.function.block.ExtentBlockCopy.apply(ExtentBlockCopy.java:71) ~[?:?]
        at com.sk89q.worldedit.function.RegionMaskingFilter.apply(RegionMaskingFilter.java:53) ~[?:?]
        at com.sk89q.worldedit.function.visitor.RegionVisitor.resume(RegionVisitor.java:57) ~[?:?]
        at com.sk89q.worldedit.function.operation.DelegateOperation.resume(DelegateOperation.java:52) ~[?:?]
        at com.sk89q.worldedit.function.operation.Operations.completeLegacy(Operations.java:55) ~[?:?]
        at com.sk89q.worldedit.command.ClipboardCommands.copy(ClipboardCommands.java:94) ~[?:?]
        ... 32 more