### PR TITLE
Cleanup javadoc warnings

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -98,7 +98,7 @@ public interface BukkitImplAdapter {
     Entity createEntity(Location location, BaseEntity state);
 
     /**
-     * Get a map of string -> properties
+     * Get a map of {@code string -> property}.
      *
      * @param blockType The block type
      * @return The properties map

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -526,7 +526,7 @@ public class LocalSession {
      * Get the tool assigned to the item.
      *
      * @param item the item type
-     * @return the tool, which may be {@link null}
+     * @return the tool, which may be {@code null}
      */
     @Nullable
     public Tool getTool(ItemType item) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/validation/BlockChangeLimiter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/validation/BlockChangeLimiter.java
@@ -41,7 +41,7 @@ public class BlockChangeLimiter extends AbstractDelegateExtent {
      * Create a new instance.
      *
      * @param extent the extent
-     * @param limit the limit (>= 0) or -1 for no limit
+     * @param limit the limit (&gt;= 0) or -1 for no limit
      */
     public BlockChangeLimiter(Extent extent, int limit) {
         super(extent);
@@ -51,7 +51,7 @@ public class BlockChangeLimiter extends AbstractDelegateExtent {
     /**
      * Get the limit.
      *
-     * @return the limit (>= 0) or -1 for no limit
+     * @return the limit (&gt;= 0) or -1 for no limit
      */
     public int getLimit() {
         return limit;
@@ -60,7 +60,7 @@ public class BlockChangeLimiter extends AbstractDelegateExtent {
     /**
      * Set the limit.
      *
-     * @param limit the limit (>= 0) or -1 for no limit
+     * @param limit the limit (&gt;= 0) or -1 for no limit
      */
     public void setLimit(int limit) {
         checkArgument(limit >= -1, "limit >= -1 required");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/Expression.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/Expression.java
@@ -41,7 +41,7 @@ import java.util.Stack;
  * <p>Supported operators:</p>
  *
  * <ul>
- *     <li>Logical: &&, ||, ! (unary)</li>
+ *     <li>Logical: &amp;&amp;, ||, ! (unary)</li>
  *     <li>Bitwise: ~ (unary), &gt;&gt;, &lt;&lt;</li>
  *     <li>Arithmetic: +, -, *, /, % (modulo), ^ (power), - (unary), --, ++ (prefix only)</li>
  *     <li>Comparison: &lt;=, &gt;=, &gt;, &lt;, ==, !=, ~= (near)</li>

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/Style.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/Style.java
@@ -221,7 +221,7 @@ public enum Style {
      * ChatColor.COLOR_CODE color code character. The alternate color code character will only be replaced
      * if it is immediately followed by 0-9, A-F, a-f, K-O, k-o, R or r.
      *
-     * @param altColorChar The alternate color code character to replace. Ex: &
+     * @param altColorChar The alternate color code character to replace. Ex: &amp;
      * @param textToTranslate Text containing the alternate color code character.
      * @return Text containing the ChatColor.COLOR_CODE color code character.
      */

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
@@ -89,7 +89,7 @@ public class BlockType {
     }
 
     /**
-     * Gets the properties of this BlockType in a key->property mapping.
+     * Gets the properties of this BlockType in a {@code key->property} mapping.
      *
      * @return The properties map
      */

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/ChunkStore.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/storage/ChunkStore.java
@@ -46,8 +46,8 @@ public abstract class ChunkStore implements Closeable {
     public static final int DATA_VERSION_MC_1_13 = 1519;
 
     /**
-     * >> to chunk
-     * << from chunk
+     * {@code >>} - to chunk
+     * {@code <<} - from chunk
      */
     public static final int CHUNK_SHIFTS = 4;
 


### PR DESCRIPTION
Compiling with Java 10 produced some Javadoc warnings because they're technically written in HTML, and some characters are forbidden without proper encoding.

This PR simply cleans up these warnings.