### PR TITLE
Flush or disable buffers in tools

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -285,7 +285,7 @@ public class WorldEditPlugin extends JavaPlugin implements TabCompleter {
         LocalSession session = WorldEdit.getInstance().getSessionManager().get(wePlayer);
 
         session.remember(editSession);
-        editSession.flushQueue();
+        editSession.flushSession();
 
         WorldEdit.getInstance().flushBlockBag(wePlayer, editSession);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -134,7 +134,7 @@ import javax.annotation.Nullable;
  * using the {@link ChangeSetExtent}.</p>
  */
 @SuppressWarnings({"FieldCanBeLocal"})
-public class EditSession implements Extent {
+public class EditSession implements Extent, AutoCloseable {
 
     private static final Logger log = Logger.getLogger(EditSession.class.getCanonicalName());
 
@@ -634,6 +634,14 @@ public class EditSession implements Extent {
     @Override
     public List<? extends Entity> getEntities() {
         return bypassNone.getEntities();
+    }
+
+    /**
+     * Closing an EditSession {@linkplain #flushSession() flushes its buffers}.
+     */
+    @Override
+    public void close() {
+        flushSession();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -415,7 +415,7 @@ public class EditSession implements Extent, AutoCloseable {
             }
             return;
         }
-        if (!batchingChunks) {
+        if (!batchingChunks && isBatchingChunks()) {
             flushSession();
         }
         chunkBatchingExtent.setEnabled(batchingChunks);
@@ -428,9 +428,15 @@ public class EditSession implements Extent, AutoCloseable {
      * @see #setBatchingChunks(boolean)
      */
     public void disableBuffering() {
-        // We optimize here to avoid double calls to flushSession.
+        // We optimize here to avoid repeated calls to flushSession.
+        boolean needsFlush = isQueueEnabled() || isBatchingChunks();
+        if (needsFlush) {
+            flushSession();
+        }
         reorderExtent.setEnabled(false);
-        setBatchingChunks(false);
+        if (chunkBatchingExtent != null) {
+            chunkBatchingExtent.setEnabled(false);
+        }
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/WorldEdit.java
@@ -628,7 +628,7 @@ public class WorldEdit {
             logger.log(Level.WARNING, "Failed to execute script", e);
         } finally {
             for (EditSession editSession : scriptContext.getEditSessions()) {
-                editSession.flushQueue();
+                editSession.flushSession();
                 session.remember(editSession);
             }
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
@@ -460,7 +460,7 @@ public class UtilityCommands {
 
         if (editSession != null) {
             session.remember(editSession);
-            editSession.flushQueue();
+            editSession.flushSession();
         }
     }
 
@@ -520,7 +520,7 @@ public class UtilityCommands {
 
         if (editSession != null) {
             session.remember(editSession);
-            editSession.flushQueue();
+            editSession.flushSession();
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
@@ -83,7 +83,7 @@ public class AreaPickaxe implements BlockTool {
         } catch (MaxChangedBlocksException e) {
             player.printError("Max blocks change limit reached.");
         } finally {
-            editSession.flushQueue();
+            editSession.flushSession();
             session.remember(editSession);
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
@@ -62,29 +62,29 @@ public class AreaPickaxe implements BlockTool {
             return true;
         }
 
-        EditSession editSession = session.createEditSession(player);
-        editSession.getSurvivalExtent().setToolUse(config.superPickaxeManyDrop);
+        try (EditSession editSession = session.createEditSession(player)) {
+            editSession.getSurvivalExtent().setToolUse(config.superPickaxeManyDrop);
 
-        try {
-            for (int x = ox - range; x <= ox + range; ++x) {
-                for (int y = oy - range; y <= oy + range; ++y) {
-                    for (int z = oz - range; z <= oz + range; ++z) {
-                        Vector pos = new Vector(x, y, z);
-                        if (editSession.getBlock(pos).getBlockType() != initialType) {
-                            continue;
+            try {
+                for (int x = ox - range; x <= ox + range; ++x) {
+                    for (int y = oy - range; y <= oy + range; ++y) {
+                        for (int z = oz - range; z <= oz + range; ++z) {
+                            Vector pos = new Vector(x, y, z);
+                            if (editSession.getBlock(pos).getBlockType() != initialType) {
+                                continue;
+                            }
+
+                            ((World) clicked.getExtent()).queueBlockBreakEffect(server, pos, initialType, clicked.toVector().distanceSq(pos));
+
+                            editSession.setBlock(pos, BlockTypes.AIR.getDefaultState());
                         }
-
-                        ((World) clicked.getExtent()).queueBlockBreakEffect(server, pos, initialType, clicked.toVector().distanceSq(pos));
-
-                        editSession.setBlock(pos, BlockTypes.AIR.getDefaultState());
                     }
                 }
+            } catch (MaxChangedBlocksException e) {
+                player.printError("Max blocks change limit reached.");
+            } finally {
+                session.remember(editSession);
             }
-        } catch (MaxChangedBlocksException e) {
-            player.printError("Max blocks change limit reached.");
-        } finally {
-            editSession.flushSession();
-            session.remember(editSession);
         }
 
         return true;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockReplacer.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockReplacer.java
@@ -52,15 +52,16 @@ public class BlockReplacer implements DoubleActionBlockTool {
     public boolean actPrimary(Platform server, LocalConfiguration config, Player player, LocalSession session, com.sk89q.worldedit.util.Location clicked) {
         BlockBag bag = session.getBlockBag(player);
 
-        EditSession editSession = session.createEditSession(player);
-        editSession.disableBuffering();
-
-        try {
-            Vector position = clicked.toVector();
-            editSession.setBlock(position, pattern.apply(position));
-        } catch (MaxChangedBlocksException ignored) {
+        try (EditSession editSession = session.createEditSession(player)) {
+            try {
+                editSession.disableBuffering();
+                Vector position = clicked.toVector();
+                editSession.setBlock(position, pattern.apply(position));
+            } catch (MaxChangedBlocksException ignored) {
+            } finally {
+                session.remember(editSession);
+            }
         } finally {
-            session.remember(editSession);
             if (bag != null) {
                 bag.flushChanges();
             }
@@ -72,8 +73,7 @@ public class BlockReplacer implements DoubleActionBlockTool {
 
     @Override
     public boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session, com.sk89q.worldedit.util.Location clicked) {
-        EditSession editSession = session.createEditSession(player);
-        BlockStateHolder targetBlock = editSession.getBlock(clicked.toVector());
+        BlockStateHolder targetBlock = player.getWorld().getBlock(clicked.toVector());
 
         if (targetBlock != null) {
             pattern = new BlockPattern(targetBlock);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockReplacer.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockReplacer.java
@@ -53,16 +53,17 @@ public class BlockReplacer implements DoubleActionBlockTool {
         BlockBag bag = session.getBlockBag(player);
 
         EditSession editSession = session.createEditSession(player);
+        editSession.disableBuffering();
 
         try {
             Vector position = clicked.toVector();
             editSession.setBlock(position, pattern.apply(position));
         } catch (MaxChangedBlocksException ignored) {
         } finally {
+            session.remember(editSession);
             if (bag != null) {
                 bag.flushChanges();
             }
-            session.remember(editSession);
         }
 
         return true;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BrushTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BrushTool.java
@@ -172,29 +172,30 @@ public class BrushTool implements TraceTool {
 
         BlockBag bag = session.getBlockBag(player);
 
-        EditSession editSession = session.createEditSession(player);
-        Request.request().setEditSession(editSession);
-        if (mask != null) {
-            Mask existingMask = editSession.getMask();
+        try (EditSession editSession = session.createEditSession(player)) {
+            Request.request().setEditSession(editSession);
+            if (mask != null) {
+                Mask existingMask = editSession.getMask();
 
-            if (existingMask == null) {
-                editSession.setMask(mask);
-            } else if (existingMask instanceof MaskIntersection) {
-                ((MaskIntersection) existingMask).add(mask);
-            } else {
-                MaskIntersection newMask = new MaskIntersection(existingMask);
-                newMask.add(mask);
-                editSession.setMask(newMask);
+                if (existingMask == null) {
+                    editSession.setMask(mask);
+                } else if (existingMask instanceof MaskIntersection) {
+                    ((MaskIntersection) existingMask).add(mask);
+                } else {
+                    MaskIntersection newMask = new MaskIntersection(existingMask);
+                    newMask.add(mask);
+                    editSession.setMask(newMask);
+                }
             }
-        }
 
-        try {
-            brush.build(editSession, target.toVector(), material, size);
-        } catch (MaxChangedBlocksException e) {
-            player.printError("Max blocks change limit reached.");
+            try {
+                brush.build(editSession, target.toVector(), material, size);
+            } catch (MaxChangedBlocksException e) {
+                player.printError("Max blocks change limit reached.");
+            } finally {
+                session.remember(editSession);
+            }
         } finally {
-            session.remember(editSession);
-            editSession.flushSession();
             if (bag != null) {
                 bag.flushChanges();
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BrushTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BrushTool.java
@@ -193,10 +193,11 @@ public class BrushTool implements TraceTool {
         } catch (MaxChangedBlocksException e) {
             player.printError("Max blocks change limit reached.");
         } finally {
+            session.remember(editSession);
+            editSession.flushSession();
             if (bag != null) {
                 bag.flushChanges();
             }
-            session.remember(editSession);
         }
 
         return true;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/RecursivePickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/RecursivePickaxe.java
@@ -66,17 +66,17 @@ public class RecursivePickaxe implements BlockTool {
             return true;
         }
 
-        EditSession editSession = session.createEditSession(player);
-        editSession.getSurvivalExtent().setToolUse(config.superPickaxeManyDrop);
+        try (EditSession editSession = session.createEditSession(player)) {
+            editSession.getSurvivalExtent().setToolUse(config.superPickaxeManyDrop);
 
-        try {
-            recurse(server, editSession, world, clicked.toVector().toBlockVector(),
-                    clicked.toVector(), range, initialType, new HashSet<>());
-        } catch (MaxChangedBlocksException e) {
-            player.printError("Max blocks change limit reached.");
-        } finally {
-            editSession.flushSession();
-            session.remember(editSession);
+            try {
+                recurse(server, editSession, world, clicked.toVector().toBlockVector(),
+                        clicked.toVector(), range, initialType, new HashSet<>());
+            } catch (MaxChangedBlocksException e) {
+                player.printError("Max blocks change limit reached.");
+            } finally {
+                session.remember(editSession);
+            }
         }
 
         return true;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/RecursivePickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/RecursivePickaxe.java
@@ -75,7 +75,7 @@ public class RecursivePickaxe implements BlockTool {
         } catch (MaxChangedBlocksException e) {
             player.printError("Max blocks change limit reached.");
         } finally {
-            editSession.flushQueue();
+            editSession.flushSession();
             session.remember(editSession);
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/SinglePickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/SinglePickaxe.java
@@ -57,7 +57,7 @@ public class SinglePickaxe implements BlockTool {
         } catch (MaxChangedBlocksException e) {
             player.printError("Max blocks change limit reached.");
         } finally {
-            editSession.flushQueue();
+            editSession.flushSession();
         }
 
         world.playEffect(clicked.toVector(), 2001, blockType.getLegacyId());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/SinglePickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/SinglePickaxe.java
@@ -49,15 +49,11 @@ public class SinglePickaxe implements BlockTool {
             return true;
         }
 
-        EditSession editSession = session.createEditSession(player);
-        editSession.getSurvivalExtent().setToolUse(config.superPickaxeDrop);
-
-        try {
+        try (EditSession editSession = session.createEditSession(player)) {
+            editSession.getSurvivalExtent().setToolUse(config.superPickaxeDrop);
             editSession.setBlock(clicked.toVector(), BlockTypes.AIR.getDefaultState());
         } catch (MaxChangedBlocksException e) {
             player.printError("Max blocks change limit reached.");
-        } finally {
-            editSession.flushSession();
         }
 
         world.playEffect(clicked.toVector(), 2001, blockType.getLegacyId());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/CommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/CommandManager.java
@@ -316,7 +316,7 @@ public final class CommandManager {
 
             if (editSession != null) {
                 session.remember(editSession);
-                editSession.flushQueue();
+                editSession.flushSession();
 
                 if (config.profile) {
                     long time = System.currentTimeMillis() - start;


### PR DESCRIPTION
`/brush` and `/repl` implementations did not flush the queue previously. This appeared to work even with the reorder extent because most blocks weren't delayed, but with chunk batching it caused total breakage. This ensures that the buffers will be flushed, or disables them entirely for single-block changes.

Note: this PR also includes an `AutoCloseable`-implementing `EditSession` for ease of flushing. It's in a separate commit, so it can be easily reverted if deemed inappropriate.