### PR TITLE
Add tracing for unflushed EditSessions

### DIFF
--- a/worldedit-bukkit/src/main/resources/defaults/config.yml
+++ b/worldedit-bukkit/src/main/resources/defaults/config.yml
@@ -139,6 +139,9 @@ history:
 calculation:
     timeout: 100
 
+debugging:
+    trace-unflushed-sessions: false
+
 wand-item: minecraft:wooden_axe
 shell-save-type:
 no-double-slash: false

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -234,6 +234,16 @@ public class EditSession implements Extent, AutoCloseable {
         return event.getExtent();
     }
 
+    // pkg private for TracedEditSession only
+
+    ChunkBatchingExtent getChunkBatchingExtent() {
+        return chunkBatchingExtent;
+    }
+
+    MultiStageReorder getReorderExtent() {
+        return reorderExtent;
+    }
+
     /**
      * Turns on specific features for a normal WorldEdit session, such as
      * {@link #enableQueue() queuing} and {@link #setBatchingChunks(boolean)

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionFactory.java
@@ -152,21 +152,24 @@ public class EditSessionFactory {
 
         @Override
         public EditSession getEditSession(World world, int maxBlocks) {
-            return new EditSession(eventBus, world, maxBlocks, null, new EditSessionEvent(world, null, maxBlocks, null));
+            return getEditSession(world, maxBlocks, null, null);
         }
 
         @Override
         public EditSession getEditSession(World world, int maxBlocks, Player player) {
-            return new EditSession(eventBus, world, maxBlocks, null, new EditSessionEvent(world, player, maxBlocks, null));
+            return getEditSession(world, maxBlocks, null, player);
         }
 
         @Override
         public EditSession getEditSession(World world, int maxBlocks, BlockBag blockBag) {
-            return new EditSession(eventBus, world, maxBlocks, blockBag, new EditSessionEvent(world, null, maxBlocks, null));
+            return getEditSession(world, maxBlocks, blockBag, null);
         }
 
         @Override
         public EditSession getEditSession(World world, int maxBlocks, BlockBag blockBag, Player player) {
+            if (WorldEdit.getInstance().getConfiguration().traceUnflushedSessions) {
+                return new TracedEditSession(eventBus, world, maxBlocks, blockBag, new EditSessionEvent(world, player, maxBlocks, null));
+            }
             return new EditSession(eventBus, world, maxBlocks, blockBag, new EditSessionEvent(world, player, maxBlocks, null));
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalConfiguration.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalConfiguration.java
@@ -100,6 +100,7 @@ public abstract class LocalConfiguration {
     };
 
     public boolean profile = false;
+    public boolean traceUnflushedSessions = false;
     public Set<String> disallowedBlocks = new HashSet<>();
     public int defaultChangeLimit = -1;
     public int maxChangeLimit = -1;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/TracedEditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/TracedEditSession.java
@@ -1,0 +1,49 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit;
+
+import com.sk89q.worldedit.event.extent.EditSessionEvent;
+import com.sk89q.worldedit.extent.inventory.BlockBag;
+import com.sk89q.worldedit.util.eventbus.EventBus;
+import com.sk89q.worldedit.world.World;
+
+import java.util.logging.Level;
+
+public class TracedEditSession extends EditSession {
+
+    TracedEditSession(EventBus eventBus, World world, int maxBlocks, BlockBag blockBag, EditSessionEvent event) {
+        super(eventBus, world, maxBlocks, blockBag, event);
+    }
+
+    private final Throwable stacktrace = new Throwable("Creation trace.");
+
+    @Override
+    protected void finalize() throws Throwable {
+        if (!isQueueEnabled() && !isBatchingChunks()) {
+            return;
+        }
+
+        if (getChunkBatchingExtent().commitRequired() || getReorderExtent().commitRequired()) {
+            WorldEdit.logger.warning("####### LEFTOVER BUFFER BLOCKS DETECTED #######");
+            WorldEdit.logger.warning("This means that some code did not flush their EditSession.");
+            WorldEdit.logger.log(Level.WARNING, "Here is a stacktrace from the creation of this EditSession:", stacktrace);
+        }
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/reorder/ChunkBatchingExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/reorder/ChunkBatchingExtent.java
@@ -73,6 +73,10 @@ public class ChunkBatchingExtent extends AbstractDelegateExtent {
         this.enabled = enabled;
     }
 
+    public boolean commitRequired() {
+        return batches.size() > 0;
+    }
+
     @Override
     public boolean setBlock(Vector location, BlockStateHolder block) throws WorldEditException {
         if (!enabled) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/reorder/MultiStageReorder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/reorder/MultiStageReorder.java
@@ -94,6 +94,10 @@ public class MultiStageReorder extends AbstractDelegateExtent implements Reorder
         this.enabled = enabled;
     }
 
+    public boolean commitRequired() {
+        return stage1.size() > 0 || stage2.size() > 0 || stage3.size() > 0;
+    }
+
     @Override
     public boolean setBlock(Vector location, BlockStateHolder block) throws WorldEditException {
         BlockState existing = getBlock(location);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/PropertiesConfiguration.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/PropertiesConfiguration.java
@@ -75,6 +75,7 @@ public class PropertiesConfiguration extends LocalConfiguration {
         loadExtra();
 
         profile = getBool("profile", profile);
+        traceUnflushedSessions = getBool("traceUnflushedSessions", traceUnflushedSessions);
         disallowedBlocks = getStringSet("disallowed-blocks", defaultDisallowedBlocks);
         defaultChangeLimit = getInt("default-max-changed-blocks", defaultChangeLimit);
         maxChangeLimit = getInt("max-changed-blocks", maxChangeLimit);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/YAMLConfiguration.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/YAMLConfiguration.java
@@ -54,6 +54,7 @@ public class YAMLConfiguration extends LocalConfiguration {
         }
 
         profile = config.getBoolean("debug", profile);
+        traceUnflushedSessions = config.getBoolean("debugging.trace-unflushed-sessions", traceUnflushedSessions);
         wandItem = convertLegacyItem(config.getString("wand-item", wandItem));
 
         defaultChangeLimit = Math.max(-1, config.getInt(

--- a/worldedit-forge/src/main/resources/defaults/worldedit.properties
+++ b/worldedit-forge/src/main/resources/defaults/worldedit.properties
@@ -5,6 +5,7 @@ super-pickaxe-many-drop-items=true
 register-help=true
 nav-wand-item=minecraft:compass
 profile=false
+traceUnflushedSessions=false
 super-pickaxe-drop-items=true
 disallowed-blocks=minecraft:oak_sapling,minecraft:jungle_sapling,minecraft:dark_oak_sapling,minecraft:spruce_sapling,minecraft:birch_sapling,minecraft:acacia_sapling,minecraft:black_bed,minecraft:blue_bed,minecraft:brown_bed,minecraft:cyan_bed,minecraft:gray_bed,minecraft:green_bed,minecraft:light_blue_bed,minecraft:light_gray_bed,minecraft:lime_bed,minecraft:magenta_bed,minecraft:orange_bed,minecraft:pink_bed,minecraft:purple_bed,minecraft:red_bed,minecraft:white_bed,minecraft:yellow_bed,minecraft:powered_rail,minecraft:detector_rail,minecraft:grass,minecraft:dead_bush,minecraft:moving_piston,minecraft:piston_head,minecraft:sunflower,minecraft:rose_bush,minecraft:dandelion,minecraft:poppy,minecraft:brown_mushroom,minecraft:red_mushroom,minecraft:tnt,minecraft:torch,minecraft:fire,minecraft:redstone_wire,minecraft:wheat,minecraft:potatoes,minecraft:carrots,minecraft:melon_stem,minecraft:pumpkin_stem,minecraft:beetroots,minecraft:rail,minecraft:lever,minecraft:redstone_torch,minecraft:redstone_wall_torch,minecraft:repeater,minecraft:comparator,minecraft:stone_button,minecraft:birch_button,minecraft:acacia_button,minecraft:dark_oak_button,minecraft:jungle_button,minecraft:oak_button,minecraft:spruce_button,minecraft:cactus,minecraft:sugar_cane,minecraft:bedrock
 max-super-pickaxe-size=5

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/config/ConfigurateConfiguration.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/config/ConfigurateConfiguration.java
@@ -58,6 +58,7 @@ public class ConfigurateConfiguration extends LocalConfiguration {
         }
 
         profile = node.getNode("debug").getBoolean(profile);
+        traceUnflushedSessions = node.getNode("debugging", "traceUnflushedSessions").getBoolean(traceUnflushedSessions);
         wandItem = node.getNode("wand-item").getString(wandItem);
         try {
             wandItem = LegacyMapper.getInstance().getItemFromLegacy(Integer.parseInt(wandItem)).getId();


### PR DESCRIPTION
With the new chunk batching, flushing is more important, as evidenced by #433 and #434. This adds a debug helper to allow developers to find leaks in tools that might otherwise appear to work fine.

Note: we may want to _enable_ this by default, as although it adds time to construction and slows down GC by a tiny amount due to the finalizer, it's probably not a huge deal because of how little EditSessions are created (only a few hundred even on busy servers).