### PR TITLE
Forge archive/1.12.2 - Updating mod for 1.12.2 using dependecy of 7.0.0 crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
 
 allprojects {
     group = 'com.sk89q.worldedit'
-    version = '6.1.9'
+    version = '6.1.10-SNAPSHOT'
 }
 
 if (!project.hasProperty("artifactory_contextUrl")) ext.artifactory_contextUrl = "http://localhost"

--- a/build.gradle
+++ b/build.gradle
@@ -87,8 +87,8 @@ subprojects {
 
     ext.internalVersion = version + ";" + gitCommitHash
 
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
     checkstyle.configFile = new File(rootProject.projectDir, "config/checkstyle/checkstyle.xml")
     checkstyle.toolVersion = '7.6.1'

--- a/worldedit-core/build.gradle
+++ b/worldedit-core/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile 'com.sk89q:jchronic:0.2.4a'
     compile 'com.google.code.findbugs:jsr305:1.3.9'
     compile 'com.thoughtworks.paranamer:paranamer:2.6'
-    compile 'com.google.code.gson:gson:2.2.4'
+    compile 'com.google.code.gson:gson:2.8.0'
     compile 'com.sk89q.lib:jlibnoise:1.0.0'
     //compile 'net.sf.trove4j:trove4j:3.0.3'
     testCompile 'org.mockito:mockito-core:1.9.0-rc1'

--- a/worldedit-forge/build.gradle
+++ b/worldedit-forge/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 
 dependencies {
     compile project(':worldedit-core')
-    compile 'org.spongepowered:spongeapi:6.0.0-SNAPSHOT'
+    compileOnly 'org.spongepowered:spongeapi:6.0.0-SNAPSHOT'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '1.9.0-rc1'
 }
 
@@ -30,11 +30,11 @@ repositories {
     }
 }
 
-ext.forgeVersion = "14.22.0.2456"
+ext.forgeVersion = "14.23.5.2768"
 
 minecraft {
-    version = "1.12.1-${project.forgeVersion}"
-    mappings = "snapshot_20170815"
+    version = "1.12.2-${project.forgeVersion}"
+    mappings = "stable_39"
     runDir = 'run'
 
     replaceIn "com/sk89q/worldedit/forge/ForgeWorldEdit.java"

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlatform.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlatform.java
@@ -79,14 +79,14 @@ class ForgePlatform extends AbstractPlatform implements MultiUserPlatform {
 
         for (Item item : Item.REGISTRY) {
             if (item == null) continue;
-            if (item.getUnlocalizedName() == null) continue;
-            if (item.getUnlocalizedName().startsWith("item.")) {
-                if (item.getUnlocalizedName().equalsIgnoreCase("item." + name)) return Item.getIdFromItem(item);
+            if (item.getTranslationKey() == null) continue;
+            if (item.getTranslationKey().startsWith("item.")) {
+                if (item.getTranslationKey().equalsIgnoreCase("item." + name)) return Item.getIdFromItem(item);
             }
-            if (item.getUnlocalizedName().startsWith("tile.")) {
-                if (item.getUnlocalizedName().equalsIgnoreCase("tile." + name)) return Item.getIdFromItem(item);
+            if (item.getTranslationKey().startsWith("tile.")) {
+                if (item.getTranslationKey().equalsIgnoreCase("tile." + name)) return Item.getIdFromItem(item);
             }
-            if (item.getUnlocalizedName().equalsIgnoreCase(name)) return Item.getIdFromItem(item);
+            if (item.getTranslationKey().equalsIgnoreCase(name)) return Item.getIdFromItem(item);
         }
         return -1;
     }

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
@@ -164,7 +164,7 @@ public class ForgeWorld extends AbstractWorld {
         int z = position.getBlockZ();
 
         // First set the block
-        Chunk chunk = world.getChunkFromChunkCoords(x >> 4, z >> 4);
+        Chunk chunk = world.getChunk(x >> 4, z >> 4);
         BlockPos pos = new BlockPos(x, y, z);
         IBlockState old = chunk.getBlockState(pos);
         @SuppressWarnings("deprecation")
@@ -226,7 +226,7 @@ public class ForgeWorld extends AbstractWorld {
         checkNotNull(position);
         checkNotNull(biome);
 
-        Chunk chunk = getWorld().getChunkFromBlockCoords(new BlockPos(position.getBlockX(), 0, position.getBlockZ()));
+        Chunk chunk = getWorld().getChunk(new BlockPos(position.getBlockX(), 0, position.getBlockZ()));
         if ((chunk != null) && (chunk.isLoaded())) {
             chunk.getBiomeArray()[((position.getBlockZ() & 0xF) << 4 | position.getBlockX() & 0xF)] = (byte) biome.getId();
             return true;
@@ -284,7 +284,7 @@ public class ForgeWorld extends AbstractWorld {
         // We need to also pull one more chunk in every direction
         CuboidRegion expandedPreGen = new CuboidRegion(region.getMinimumPoint().subtract(16, 0, 16), region.getMaximumPoint().add(16, 0, 16));
         for (Vector2D chunk : expandedPreGen.getChunks()) {
-            freshWorld.getChunkFromChunkCoords(chunk.getBlockX(), chunk.getBlockZ());
+            freshWorld.getChunk(chunk.getBlockX(), chunk.getBlockZ());
         }
         
         ForgeWorld from = new ForgeWorld(freshWorld);

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/net/LeftClickAirEventMessage.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/net/LeftClickAirEventMessage.java
@@ -33,7 +33,7 @@ public class LeftClickAirEventMessage implements IMessage {
 
         @Override
         public IMessage onMessage(LeftClickAirEventMessage message, final MessageContext ctx) {
-            ctx.getServerHandler().player.mcServer.addScheduledTask(new Runnable() {
+            ctx.getServerHandler().player.server.addScheduledTask(new Runnable() {
 
                 @Override
                 public void run() {


### PR DESCRIPTION
2018-11-18 09:30:21,297 main WARN Disabling terminal, you're running in an unsupported environment.
[09:30:21] [main/INFO] [GradleStart]: Extra: []
[09:30:21] [main/INFO] [GradleStart]: Running with arguments: [--userProperties, {}, --assetsDir, C:/Users/user/.gradle/caches/minecraft/assets, --assetIndex, 1.12, --accessToken{REDACTED}, --version, 1.12.2, --tweakClass, net.minecraftforge.fml.common.launcher.FMLTweaker, --tweakClass, net.minecraftforge.gradle.tweakers.CoremodTweaker]
[09:30:21] [main/INFO] [LaunchWrapper]: Loading tweak class name net.minecraftforge.fml.common.launcher.FMLTweaker
[09:30:21] [main/INFO] [LaunchWrapper]: Using primary tweak class name net.minecraftforge.fml.common.launcher.FMLTweaker
[09:30:21] [main/INFO] [LaunchWrapper]: Loading tweak class name net.minecraftforge.gradle.tweakers.CoremodTweaker
[09:30:21] [main/INFO] [LaunchWrapper]: Calling tweak class net.minecraftforge.fml.common.launcher.FMLTweaker
[09:30:21] [main/INFO] [FML]: Forge Mod Loader version 14.23.4.2705 for Minecraft 1.12.2 loading
[09:30:21] [main/INFO] [FML]: Java is Java HotSpot(TM) 64-Bit Server VM, version 1.8.0_181, running on Windows 10:amd64:10.0, installed at C:\Program Files\Java\jre1.8.0_181
[09:30:21] [main/ERROR] [FML]: Apache Maven library folder was not in the format expected. Using default libraries directory.
[09:30:21] [main/ERROR] [FML]: Full: C:\Users\user\.gradle\caches\modules-2\files-2.1\org.apache.maven\maven-artifact\3.5.3\7dc72b6d6d8a6dced3d294ed54c2cc3515ade9f4\maven-artifact-3.5.3.jar
[09:30:21] [main/ERROR] [FML]: Trimmed: c:/users/user/.gradle/caches/modules-2/files-2.1/org.apache.maven/maven-artifact/3.5.3/
[09:30:22] [main/INFO] [FML]: Managed to load a deobfuscated Minecraft name- we are in a deobfuscated environment. Skipping runtime deobfuscation
[09:30:22] [main/INFO] [FML]: Ignoring missing certificate for coremod FMLCorePlugin (net.minecraftforge.fml.relauncher.FMLCorePlugin), we are in deobf and it's a forge core plugin
[09:30:22] [main/INFO] [FML]: Ignoring missing certificate for coremod FMLForgePlugin (net.minecraftforge.classloading.FMLForgePlugin), we are in deobf and it's a forge core plugin
[09:30:22] [main/INFO] [FML]: Searching E:\Jayrol\Monster Hunter Frontier Craft\MHFC\run\.\mods for mods
[09:30:22] [main/INFO] [LaunchWrapper]: Calling tweak class net.minecraftforge.gradle.tweakers.CoremodTweaker
[09:30:22] [main/INFO] [GradleStart]: Injecting location in coremod net.minecraftforge.fml.relauncher.FMLCorePlugin
[09:30:22] [main/INFO] [GradleStart]: Injecting location in coremod net.minecraftforge.classloading.FMLForgePlugin
[09:30:22] [main/INFO] [LaunchWrapper]: Loading tweak class name net.minecraftforge.fml.common.launcher.FMLInjectionAndSortingTweaker
[09:30:22] [main/INFO] [LaunchWrapper]: Loading tweak class name net.minecraftforge.fml.common.launcher.FMLDeobfTweaker
[09:30:22] [main/INFO] [LaunchWrapper]: Loading tweak class name net.minecraftforge.gradle.tweakers.AccessTransformerTweaker
[09:30:22] [main/INFO] [LaunchWrapper]: Calling tweak class net.minecraftforge.fml.common.launcher.FMLInjectionAndSortingTweaker
[09:30:22] [main/INFO] [LaunchWrapper]: Calling tweak class net.minecraftforge.fml.common.launcher.FMLInjectionAndSortingTweaker
[09:30:22] [main/INFO] [LaunchWrapper]: Calling tweak class net.minecraftforge.fml.relauncher.CoreModManager$FMLPluginWrapper
[09:30:26] [main/ERROR] [FML]: FML appears to be missing any signature data. This is not a good thing
[09:30:26] [main/INFO] [LaunchWrapper]: Calling tweak class net.minecraftforge.fml.relauncher.CoreModManager$FMLPluginWrapper
[09:30:26] [main/INFO] [LaunchWrapper]: Calling tweak class net.minecraftforge.fml.common.launcher.FMLDeobfTweaker
[09:30:27] [main/INFO] [LaunchWrapper]: Calling tweak class net.minecraftforge.gradle.tweakers.AccessTransformerTweaker
[09:30:27] [main/INFO] [LaunchWrapper]: Loading tweak class name net.minecraftforge.fml.common.launcher.TerminalTweaker
[09:30:27] [main/INFO] [LaunchWrapper]: Calling tweak class net.minecraftforge.fml.common.launcher.TerminalTweaker
[09:30:27] [main/INFO] [LaunchWrapper]: Launching wrapped minecraft {net.minecraft.client.main.Main}
[09:30:29] [main/INFO] [net.minecraft.client.Minecraft]: Setting user: Player975
[09:30:39] [main/WARN] [net.minecraft.client.settings.GameSettings]: Skipping bad option: lastServer:
[09:30:39] [main/INFO] [net.minecraft.client.Minecraft]: LWJGL Version: 2.9.4
[09:30:41] [main/INFO] [FML]: -- System Details --
Details:
	Minecraft Version: 1.12.2
	Operating System: Windows 10 (amd64) version 10.0
	Java Version: 1.8.0_181, Oracle Corporation
	Java VM Version: Java HotSpot(TM) 64-Bit Server VM (mixed mode), Oracle Corporation
	Memory: 216716720 bytes (206 MB) / 619184128 bytes (590 MB) up to 3797417984 bytes (3621 MB)
	JVM Flags: 0 total; 
	IntCache: cache: 0, tcache: 0, allocated: 0, tallocated: 0
	FML: 
	Loaded coremods (and transformers): 
	GL info: ' Vendor: 'Intel' Version: '4.4.0 - Build 20.19.15.4835' Renderer: 'Intel(R) HD Graphics 5500'
[09:30:41] [main/INFO] [FML]: MinecraftForge v14.23.4.2705 Initialized
[09:30:41] [main/INFO] [FML]: Starts to replace vanilla recipe ingredients with ore ingredients.
[09:30:42] [main/INFO] [FML]: Replaced 1036 ore ingredients
[09:30:43] [main/INFO] [FML]: Searching E:\Jayrol\Monster Hunter Frontier Craft\MHFC\run\.\mods for mods
[09:30:47] [main/WARN] [FML]: Mod mhfc is missing the required element 'version' and a version.properties file could not be found. Falling back to metadata version ${version}
[09:30:49] [Thread-3/INFO] [FML]: Using alternative sync timing : 200 frames of Display.update took 4967171967 nanos
[09:30:49] [main/INFO] [FML]: Forge Mod Loader has identified 7 mods to load
[09:30:50] [main/INFO] [FML]: Attempting connection with missing mods [minecraft, mcp, FML, forge, mhfc, mcanm, worldedit] at CLIENT
[09:30:50] [main/INFO] [FML]: Attempting connection with missing mods [minecraft, mcp, FML, forge, mhfc, mcanm, worldedit] at SERVER
[09:30:53] [main/INFO] [net.minecraft.client.resources.SimpleReloadableResourceManager]: Reloading ResourceManager: Default, FMLFileResourcePack:Forge Mod Loader, FMLFileResourcePack:Minecraft Forge, FMLFileResourcePack:Monster Hunter Frontier Craft, FMLFileResourcePack:Minecraft Animated, FMLFileResourcePack:WorldEdit
[09:30:54] [main/INFO] [FML]: Processing ObjectHolder annotations
[09:30:54] [main/INFO] [FML]: Found 1168 ObjectHolder annotations
[09:30:54] [main/INFO] [FML]: Identifying ItemStackHolder annotations
[09:30:54] [main/INFO] [FML]: Found 0 ItemStackHolder annotations
[09:30:54] [main/INFO] [FML]: Configured a dormant chunk cache size of 0
[09:30:54] [Forge Version Check/INFO] [forge.VersionCheck]: [forge] Starting version check at http://files.minecraftforge.net/maven/net/minecraftforge/forge/promotions_slim.json
[09:30:55] [Forge Version Check/INFO] [forge.VersionCheck]: [forge] Found status: OUTDATED Target: 14.23.5.2768
[09:30:55] [Forge Version Check/INFO] [forge.VersionCheck]: [mhfc] Starting version check at https://raw.githubusercontent.com/Guild-Hall/MHFC/updates/update.json
[09:30:55] [main/INFO] [mcanm]: Successfully loaded MC Animations
[09:30:56] [Forge Version Check/INFO] [forge.VersionCheck]: [mhfc] Found status: BETA Target: null
[09:30:57] [main/INFO] [STDOUT]: [net.minecraft.init.Bootstrap:printToSYSOUT:629]: ---- Minecraft Crash Report ----
// Surprise! Haha. Well, this is awkward.

Time: 11/18/18 9:30 AM
Description: There was a severe problem during mod loading that has caused the game to fail

net.minecraftforge.fml.common.LoaderExceptionModCrash: Caught exception from WorldEdit (worldedit)
Caused by: java.lang.ExceptionInInitializerError
	at com.sk89q.worldedit.LocalConfiguration.<clinit>(LocalConfiguration.java:37)
	at com.sk89q.worldedit.forge.ForgeWorldEdit.preInit(ForgeWorldEdit.java:93)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at net.minecraftforge.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:629)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
	at net.minecraftforge.fml.common.LoadController.sendEventToModContainer(LoadController.java:218)
	at net.minecraftforge.fml.common.LoadController.propogateStateMessage(LoadController.java:196)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
	at net.minecraftforge.fml.common.LoadController.distributeStateMessage(LoadController.java:135)
	at net.minecraftforge.fml.common.Loader.preinitializeMods(Loader.java:627)
	at net.minecraftforge.fml.client.FMLClientHandler.beginMinecraftLoading(FMLClientHandler.java:245)
	at net.minecraft.client.Minecraft.init(Minecraft.java:513)
	at net.minecraft.client.Minecraft.run(Minecraft.java:421)
	at net.minecraft.client.main.Main.main(Main.java:118)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at net.minecraftforge.gradle.GradleStartCommon.launch(GradleStartCommon.java:97)
	at GradleStart.main(GradleStart.java:25)
Caused by: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(Unknown Source)
	at java.util.ArrayList.get(Unknown Source)
	at com.sk89q.worldedit.extension.platform.PlatformManager.queryCapability(PlatformManager.java:169)
	at com.sk89q.worldedit.world.block.BlockType.getPropertyMap(BlockType.java:97)
	at com.sk89q.worldedit.world.block.BlockType.getProperties(BlockType.java:108)
	at com.sk89q.worldedit.world.block.BlockState.generateStateMap(BlockState.java:77)
	at com.sk89q.worldedit.world.block.BlockType.<init>(BlockType.java:60)
	at com.sk89q.worldedit.world.block.BlockTypes.register(BlockTypes.java:635)
	at com.sk89q.worldedit.world.block.BlockTypes.<clinit>(BlockTypes.java:33)
	... 49 more


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- System Details --
Details:
	Minecraft Version: 1.12.2
	Operating System: Windows 10 (amd64) version 10.0
	Java Version: 1.8.0_181, Oracle Corporation
	Java VM Version: Java HotSpot(TM) 64-Bit Server VM (mixed mode), Oracle Corporation
	Memory: 388670680 bytes (370 MB) / 865075200 bytes (825 MB) up to 3797417984 bytes (3621 MB)
	JVM Flags: 0 total; 
	IntCache: cache: 0, tcache: 0, allocated: 0, tallocated: 0
	FML: MCP 9.42 Powered by Forge 14.23.4.2705 7 mods loaded, 7 mods active
	States: 'U' = Unloaded 'L' = Loaded 'C' = Constructed 'H' = Pre-initialized 'I' = Initialized 'J' = Post-initialized 'A' = Available 'D' = Disabled 'E' = Errored

	| State | ID        | Version        | Source                                      | Signature |
	|:----- |:--------- |:-------------- |:------------------------------------------- |:--------- |
	| UCH   | minecraft | 1.12.2         | minecraft.jar                               | None      |
	| UCH   | mcp       | 9.42           | minecraft.jar                               | None      |
	| UCH   | FML       | 8.0.99.99      | forgeSrc-1.12.2-14.23.4.2705.jar            | None      |
	| UCH   | forge     | 14.23.4.2705   | forgeSrc-1.12.2-14.23.4.2705.jar            | None      |
	| UCH   | mcanm     | 2.7.4.149      | MCAnm-v2.7.46-deobf.jar                     | None      |
	| UCEE  | worldedit | 7.0.0-SNAPSHOT | worldedit-forge-mc1.12.1-7.0.0-SNAPSHOT.jar | None      |
	| UC    | mhfc      | ${version}     | bin                                         | None      |

	Loaded coremods (and transformers): 
	GL info: ' Vendor: 'Intel' Version: '4.4.0 - Build 20.19.15.4835' Renderer: 'Intel(R) HD Graphics 5500'
[09:30:57] [main/INFO] [STDOUT]: [net.minecraft.init.Bootstrap:printToSYSOUT:629]: #@!@# Game crashed! Crash report saved to: #@!@# E:\Jayrol\Monster Hunter Frontier Craft\MHFC\run\.\crash-reports\crash-2018-11-18_09.30.57-client.txt