### PR TITLE
Add check for unchanged materials in BlockBagExtent

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/inventory/BlockBagExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/inventory/BlockBagExtent.java
@@ -86,25 +86,27 @@ public class BlockBagExtent extends AbstractDelegateExtent {
         if (blockBag != null) {
             BlockState existing = getExtent().getBlock(position);
 
-            if (!block.getBlockType().getMaterial().isAir()) {
-                try {
-                    blockBag.fetchPlacedBlock(block.toImmutableState());
-                } catch (UnplaceableBlockException e) {
-                    return false;
-                } catch (BlockBagException e) {
-                    if (!missingBlocks.containsKey(block.getBlockType())) {
-                        missingBlocks.put(block.getBlockType(), 1);
-                    } else {
-                        missingBlocks.put(block.getBlockType(), missingBlocks.get(block.getBlockType()) + 1);
+            if (!block.getBlockType().equals(existing.getBlockType())) {
+                if (!block.getBlockType().getMaterial().isAir()) {
+                    try {
+                        blockBag.fetchPlacedBlock(block.toImmutableState());
+                    } catch (UnplaceableBlockException e) {
+                        return false;
+                    } catch (BlockBagException e) {
+                        if (!missingBlocks.containsKey(block.getBlockType())) {
+                            missingBlocks.put(block.getBlockType(), 1);
+                        } else {
+                            missingBlocks.put(block.getBlockType(), missingBlocks.get(block.getBlockType()) + 1);
+                        }
+                        return false;
                     }
-                    return false;
                 }
-            }
 
-            if (!existing.getBlockType().getMaterial().isAir()) {
-                try {
-                    blockBag.storeDroppedBlock(existing);
-                } catch (BlockBagException ignored) {
+                if (!existing.getBlockType().getMaterial().isAir()) {
+                    try {
+                        blockBag.storeDroppedBlock(existing);
+                    } catch (BlockBagException ignored) {
+                    }
                 }
             }
         }


### PR DESCRIPTION
I have written my own BlockBag and don't want to handle unchanged materials.
Maybe it is possible to change the behavior of the BlockBagExtent :)

Current behavoir:
Set new Block: Check for the necessary item in the inventory (fetchBlock). Store the old block after getting the new one.
That's okay, better take the placed item first. But if you want to change a block with the same material, you have two unnecessary operations.