### PR TITLE
Fix Metrics injection for Sponge distributive

### DIFF
--- a/worldedit-sponge/build.gradle
+++ b/worldedit-sponge/build.gradle
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
     compile project(':worldedit-core')
-    compile 'org.spongepowered:spongeapi:7.0.0-SNAPSHOT'
+    compile 'org.spongepowered:spongeapi:7.1.0'
     compile 'org.bstats:bstats-sponge:1.4'
     testCompile group: 'org.mockito', name: 'mockito-core', version:'1.9.0-rc1'
 }

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
@@ -34,7 +34,7 @@ import com.sk89q.worldedit.sponge.adapter.SpongeImplAdapter;
 import com.sk89q.worldedit.sponge.adapter.SpongeImplLoader;
 import com.sk89q.worldedit.sponge.config.SpongeConfiguration;
 import com.sk89q.worldedit.world.item.ItemTypes;
-import org.bstats.sponge.Metrics;
+import org.bstats.sponge.Metrics2;
 import org.slf4j.Logger;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
@@ -77,7 +77,7 @@ public class SpongeWorldEdit {
     private Logger logger;
 
     @Inject
-    private Metrics metrics;
+    private Metrics2 metrics;
 
     public static final String MOD_ID = "worldedit";
 


### PR DESCRIPTION
[crash-2018-12-24_16.03.01-server.txt](https://github.com/sk89q/WorldEdit/files/2707208/crash-2018-12-24_16.03.01-server.txt)

Server crashed at start, because Google Guice can't find implementation for Metrics interface. I replaced it to Metrics2 class.