### PR TITLE
Fix BlockType and ItemType registration for Sponge distributive

### DIFF
--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorldEdit.java
@@ -139,11 +139,17 @@ public class SpongeWorldEdit {
 
         for (BlockType blockType : Sponge.getRegistry().getAllOf(BlockType.class)) {
             // TODO Handle blockstate stuff
-            com.sk89q.worldedit.world.block.BlockTypes.register(new com.sk89q.worldedit.world.block.BlockType(blockType.getId()));
+            String id = blockType.getId();
+            if (!com.sk89q.worldedit.world.block.BlockType.REGISTRY.keySet().contains(id)) {
+                com.sk89q.worldedit.world.block.BlockTypes.register(new com.sk89q.worldedit.world.block.BlockType(id));
+            }
         }
 
         for (ItemType itemType : Sponge.getRegistry().getAllOf(ItemType.class)) {
-            ItemTypes.register(new com.sk89q.worldedit.world.item.ItemType(itemType.getId()));
+            String id = itemType.getId();
+            if (!com.sk89q.worldedit.world.item.ItemType.REGISTRY.keySet().contains(id)) {
+                ItemTypes.register(new com.sk89q.worldedit.world.item.ItemType(id));
+            }
         }
 
         WorldEdit.getInstance().getPlatformManager().register(platform);


### PR DESCRIPTION
[2018-12-24-6.log](https://github.com/sk89q/WorldEdit/files/2707671/2018-12-24-6.log)
Plugin initialization failed due to double registration from BlockTypes/ItemTypes classes and Sponge registry.

P.S. I know, that WorldEdit 7 is for 1.13, not 1.12.2, but I think that this problem will be relevant for future versions too.