### PR TITLE
Cleanup compiler warnings and BlockStateHolder raw types

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitAdapter.java
@@ -381,7 +381,7 @@ public class BukkitAdapter {
      * @param block The WorldEdit BlockStateHolder
      * @return The Bukkit BlockData
      */
-    public static BlockData adapt(BlockStateHolder block) {
+    public static <B extends BlockStateHolder<B>> BlockData adapt(B block) {
         checkNotNull(block);
         return blockDataCache.computeIfAbsent(block.getAsString(), new Function<String, BlockData>() {
             @Nullable

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
@@ -47,7 +47,7 @@ public class BukkitBlockRegistry extends BundledBlockRegistry {
 
     @Nullable
     @Override
-    public Map<String, ? extends Property> getProperties(BlockType blockType) {
+    public Map<String, ? extends Property<?>> getProperties(BlockType blockType) {
         if (WorldEditPlugin.getInstance().getBukkitImplAdapter() != null) {
             return WorldEditPlugin.getInstance().getBukkitImplAdapter().getProperties(blockType);
         }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -255,7 +255,7 @@ public class BukkitPlayer extends AbstractPlayerActor {
     }
 
     @Override
-    public void sendFakeBlock(BlockVector3 pos, BlockStateHolder block) {
+    public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, B block) {
         Location loc = new Location(player.getWorld(), pos.getX(), pos.getY(), pos.getZ());
         if (block == null) {
             player.sendBlockChange(loc, player.getWorld().getBlockAt(loc).getBlockData());

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -166,7 +166,7 @@ public class BukkitWorld extends AbstractWorld {
 
     @Override
     public boolean regenerate(Region region, EditSession editSession) {
-        BlockStateHolder[] history = new BlockStateHolder[16 * 16 * (getMaxY() + 1)];
+        BaseBlock[] history = new BaseBlock[16 * 16 * (getMaxY() + 1)];
 
         for (BlockVector2 chunk : region.getChunks()) {
             BlockVector3 min = BlockVector3.at(chunk.getBlockX() * 16, 0, chunk.getBlockZ() * 16);
@@ -421,7 +421,7 @@ public class BukkitWorld extends AbstractWorld {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 position, BlockStateHolder block, boolean notifyAndLight) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block, boolean notifyAndLight) throws WorldEditException {
         BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
         if (adapter != null) {
             try {

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -77,7 +77,7 @@ public interface BukkitImplAdapter {
      * @param notifyAndLight notify and light if set
      * @return true if a block was likely changed
      */
-    boolean setBlock(Location location, BlockStateHolder state, boolean notifyAndLight);
+    boolean setBlock(Location location, BlockStateHolder<?> state, boolean notifyAndLight);
 
     /**
      * Notifies the simulation that the block at the given location has
@@ -113,7 +113,7 @@ public interface BukkitImplAdapter {
      * @param blockType The block type
      * @return The properties map
      */
-    Map<String, ? extends Property> getProperties(BlockType blockType);
+    Map<String, ? extends Property<?>> getProperties(BlockType blockType);
 
     /**
      * Send the given NBT data to the player.

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplLoader.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplLoader.java
@@ -87,7 +87,7 @@ public class BukkitImplLoader {
         Closer closer = Closer.create();
         JarFile jar = closer.register(new JarFile(file));
         try {
-            Enumeration entries = jar.entries();
+            Enumeration<JarEntry> entries = jar.entries();
             while (entries.hasMoreElements()) {
                 JarEntry jarEntry = (JarEntry) entries.nextElement();
 

--- a/worldedit-core/src/main/java/com/sk89q/jnbt/ListTagBuilder.java
+++ b/worldedit-core/src/main/java/com/sk89q/jnbt/ListTagBuilder.java
@@ -97,7 +97,7 @@ public class ListTagBuilder {
      *
      * @return a new builder
      */
-    public static <T extends Tag> ListTagBuilder createWith(T ... entries) {
+    public static ListTagBuilder createWith(Tag... entries) {
         checkNotNull(entries);
 
         if (entries.length == 0) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -609,7 +609,7 @@ public class EditSession implements Extent, AutoCloseable {
      * @return whether the block changed
      * @throws WorldEditException thrown on a set error
      */
-    public boolean setBlock(BlockVector3 position, BlockStateHolder block, Stage stage) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block, Stage stage) throws WorldEditException {
         switch (stage) {
             case BEFORE_HISTORY:
                 return bypassNone.setBlock(position, block);
@@ -629,7 +629,7 @@ public class EditSession implements Extent, AutoCloseable {
      * @param block the block
      * @return whether the block changed
      */
-    public boolean rawSetBlock(BlockVector3 position, BlockStateHolder block) {
+    public <B extends BlockStateHolder<B>> boolean rawSetBlock(BlockVector3 position, B block) {
         try {
             return setBlock(position, block, Stage.BEFORE_CHANGE);
         } catch (WorldEditException e) {
@@ -644,7 +644,7 @@ public class EditSession implements Extent, AutoCloseable {
      * @param block the block
      * @return whether the block changed
      */
-    public boolean smartSetBlock(BlockVector3 position, BlockStateHolder block) {
+    public <B extends BlockStateHolder<B>> boolean smartSetBlock(BlockVector3 position, B block) {
         try {
             return setBlock(position, block, Stage.BEFORE_REORDER);
         } catch (WorldEditException e) {
@@ -653,7 +653,7 @@ public class EditSession implements Extent, AutoCloseable {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 position, BlockStateHolder block) throws MaxChangedBlocksException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block) throws MaxChangedBlocksException {
         try {
             return setBlock(position, block, Stage.BEFORE_HISTORY);
         } catch (MaxChangedBlocksException e) {
@@ -779,7 +779,7 @@ public class EditSession implements Extent, AutoCloseable {
      * @param searchBlocks the list of blocks to search
      * @return the number of blocks that matched the pattern
      */
-    public int countBlocks(Region region, Set<BlockStateHolder> searchBlocks) {
+    public int countBlocks(Region region, Set<BaseBlock> searchBlocks) {
         BlockMask mask = new BlockMask(this, searchBlocks);
         Counter count = new Counter();
         RegionMaskingFilter filter = new RegionMaskingFilter(mask, count);
@@ -799,7 +799,7 @@ public class EditSession implements Extent, AutoCloseable {
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
-    public int fillXZ(BlockVector3 origin, BlockStateHolder block, double radius, int depth, boolean recursive) throws MaxChangedBlocksException {
+    public <B extends BlockStateHolder<B>> int fillXZ(BlockVector3 origin, B block, double radius, int depth, boolean recursive) throws MaxChangedBlocksException {
         return fillXZ(origin, new BlockPattern(block), radius, depth, recursive);
     }
 
@@ -922,7 +922,7 @@ public class EditSession implements Extent, AutoCloseable {
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
-    public int setBlocks(Region region, BlockStateHolder block) throws MaxChangedBlocksException {
+    public <B extends BlockStateHolder<B>> int setBlocks(Region region, B block) throws MaxChangedBlocksException {
         return setBlocks(region, new BlockPattern(block));
     }
 
@@ -954,7 +954,7 @@ public class EditSession implements Extent, AutoCloseable {
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
-    public int replaceBlocks(Region region, Set<BlockStateHolder> filter, BlockStateHolder replacement) throws MaxChangedBlocksException {
+    public <B extends BlockStateHolder<B>> int replaceBlocks(Region region, Set<BaseBlock> filter, B replacement) throws MaxChangedBlocksException {
         return replaceBlocks(region, filter, new BlockPattern(replacement));
     }
 
@@ -968,7 +968,7 @@ public class EditSession implements Extent, AutoCloseable {
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
-    public int replaceBlocks(Region region, Set<BlockStateHolder> filter, Pattern pattern) throws MaxChangedBlocksException {
+    public int replaceBlocks(Region region, Set<BaseBlock> filter, Pattern pattern) throws MaxChangedBlocksException {
         Mask mask = filter == null ? new ExistingBlockMask(this) : new BlockMask(this, filter);
         return replaceBlocks(region, mask, pattern);
     }
@@ -1026,7 +1026,7 @@ public class EditSession implements Extent, AutoCloseable {
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
-    public int makeCuboidFaces(Region region, BlockStateHolder block) throws MaxChangedBlocksException {
+    public <B extends BlockStateHolder<B>> int makeCuboidFaces(Region region, B block) throws MaxChangedBlocksException {
         return makeCuboidFaces(region, new BlockPattern(block));
     }
 
@@ -1078,7 +1078,7 @@ public class EditSession implements Extent, AutoCloseable {
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
-    public int makeCuboidWalls(Region region, BlockStateHolder block) throws MaxChangedBlocksException {
+    public <B extends BlockStateHolder<B>> int makeCuboidWalls(Region region, B block) throws MaxChangedBlocksException {
         return makeCuboidWalls(region, new BlockPattern(block));
     }
 
@@ -1121,7 +1121,7 @@ public class EditSession implements Extent, AutoCloseable {
             final int maxY = region.getMaximumPoint().getBlockY();
             final ArbitraryShape shape = new RegionShape(region) {
                 @Override
-                protected BlockStateHolder getMaterial(int x, int y, int z, BlockStateHolder defaultMaterial) {
+                protected BaseBlock getMaterial(int x, int y, int z, BaseBlock defaultMaterial) {
                     if (y > maxY || y < minY) {
                         // Put holes into the floor and ceiling by telling ArbitraryShape that the shape goes on outside the region
                         return defaultMaterial;
@@ -1143,7 +1143,7 @@ public class EditSession implements Extent, AutoCloseable {
      * @return number of blocks affected
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
-    public int overlayCuboidBlocks(Region region, BlockStateHolder block) throws MaxChangedBlocksException {
+    public <B extends BlockStateHolder<B>> int overlayCuboidBlocks(Region region, B block) throws MaxChangedBlocksException {
         checkNotNull(block);
 
         return overlayCuboidBlocks(region, new BlockPattern(block));
@@ -1831,8 +1831,8 @@ public class EditSession implements Extent, AutoCloseable {
      * @param region a region
      * @return the results
      */
-    public List<Countable<BlockStateHolder>> getBlockDistribution(Region region, boolean fuzzy) {
-        BlockDistributionCounter count = new BlockDistributionCounter(this, fuzzy);
+    public List<Countable<BlockState>> getBlockDistribution(Region region, boolean separateStates) {
+        BlockDistributionCounter count = new BlockDistributionCounter(this, separateStates);
         RegionVisitor visitor = new RegionVisitor(region, count);
         Operations.completeBlindly(visitor);
         return count.getDistribution();
@@ -1850,7 +1850,7 @@ public class EditSession implements Extent, AutoCloseable {
 
         final ArbitraryShape shape = new ArbitraryShape(region) {
             @Override
-            protected BlockStateHolder getMaterial(int x, int y, int z, BlockStateHolder defaultMaterial) {
+            protected BaseBlock getMaterial(int x, int y, int z, BaseBlock defaultMaterial) {
                 final Vector3 current = Vector3.at(x, y, z);
                 environment.setCurrentBlock(current);
                 final Vector3 scaled = current.subtract(zero).divide(unit);
@@ -1861,7 +1861,7 @@ public class EditSession implements Extent, AutoCloseable {
                         return null;
                     }
 
-                    return LegacyMapper.getInstance().getBlockFromLegacy((int) typeVariable.getValue(), (int) dataVariable.getValue());
+                    return LegacyMapper.getInstance().getBlockFromLegacy((int) typeVariable.getValue(), (int) dataVariable.getValue()).toBaseBlock();
                 } catch (Exception e) {
                     log.log(Level.WARNING, "Failed to create shape", e);
                     return null;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/Blocks.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/blocks/Blocks.java
@@ -38,9 +38,9 @@ public final class Blocks {
      * @param o the block
      * @return true if the collection contains the given block
      */
-    public static boolean containsFuzzy(Collection<? extends BlockStateHolder> collection, BlockStateHolder o) {
+    public static <B extends BlockStateHolder<B>> boolean containsFuzzy(Collection<? extends BlockStateHolder<?>> collection, B o) {
         // Allow masked data in the searchBlocks to match various types
-        for (BlockStateHolder b : collection) {
+        for (BlockStateHolder<?> b : collection) {
             if (b.equalsFuzzy(o)) {
                 return true;
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/NavigationCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/NavigationCommands.java
@@ -40,7 +40,6 @@ import com.sk89q.worldedit.util.command.parametric.Optional;
  */
 public class NavigationCommands {
 
-    @SuppressWarnings("unused")
     private final WorldEdit worldEdit;
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -62,7 +62,6 @@ import com.sk89q.worldedit.util.command.binding.Range;
 import com.sk89q.worldedit.util.command.binding.Switch;
 import com.sk89q.worldedit.util.command.binding.Text;
 import com.sk89q.worldedit.util.command.parametric.Optional;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
@@ -57,7 +57,8 @@ import com.sk89q.worldedit.util.formatting.Style;
 import com.sk89q.worldedit.util.formatting.StyledFragment;
 import com.sk89q.worldedit.util.formatting.component.CommandListBox;
 import com.sk89q.worldedit.world.World;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.item.ItemTypes;
 import com.sk89q.worldedit.world.storage.ChunkStore;
 
@@ -638,7 +639,7 @@ public class SelectionCommands {
         context.setSession(session);
         context.setRestricted(false);
 
-        Set<BlockStateHolder> searchBlocks = we.getBlockFactory().parseFromListInput(args.getString(0), context);
+        Set<BaseBlock> searchBlocks = we.getBlockFactory().parseFromListInput(args.getString(0), context);
         int count = editSession.countBlocks(session.getSelection(player.getWorld()), searchBlocks);
         player.print("Counted: " + count);
     }
@@ -659,14 +660,14 @@ public class SelectionCommands {
     public void distr(Player player, LocalSession session, EditSession editSession, CommandContext args) throws WorldEditException, CommandException {
 
         int size;
-        boolean useData = args.hasFlag('d');
-        List<Countable<BlockStateHolder>> distribution;
+        boolean separateStates = args.hasFlag('d');
+        List<Countable<BlockState>> distribution;
 
         if (args.hasFlag('c')) {
             // TODO: Update for new clipboard
             throw new CommandException("Needs to be re-written again");
         } else {
-            distribution = editSession.getBlockDistribution(session.getSelection(player.getWorld()), !useData);
+            distribution = editSession.getBlockDistribution(session.getSelection(player.getWorld()), separateStates);
             size = session.getSelection(player.getWorld()).getArea();
         }
 
@@ -677,10 +678,10 @@ public class SelectionCommands {
 
         player.print("# total blocks: " + size);
 
-        for (Countable<BlockStateHolder> c : distribution) {
+        for (Countable<BlockState> c : distribution) {
             String name = c.getID().getBlockType().getName();
             String str;
-            if (useData) {
+            if (separateStates) {
                 str = String.format("%-7s (%.3f%%) %s #%s",
                         String.valueOf(c.getAmount()),
                         c.getAmount() / (double) size * 100,

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
@@ -64,7 +64,7 @@ import com.sk89q.worldedit.util.formatting.component.Code;
 import com.sk89q.worldedit.util.formatting.component.CommandListBox;
 import com.sk89q.worldedit.util.formatting.component.CommandUsageBox;
 import com.sk89q.worldedit.world.World;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockTypes;
 
 import java.util.ArrayList;
@@ -250,7 +250,7 @@ public class UtilityCommands {
         context.setRestricted(false);
         context.setPreferringWildcard(false);
 
-        BlockStateHolder block = we.getBlockFactory().parseFromInput(args.getString(0), context);
+        BaseBlock block = we.getBlockFactory().parseFromInput(args.getString(0), context);
         int size = Math.max(1, args.getInteger(1, 50));
         we.checkMaxRadius(size);
 
@@ -272,7 +272,7 @@ public class UtilityCommands {
         
         int size = Math.max(1, args.getInteger(0));
         int affected;
-        Set<BlockStateHolder> from;
+        Set<BaseBlock> from;
         Pattern to;
 
         ParserContext context = new ParserContext();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockDataCyler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockDataCyler.java
@@ -68,7 +68,7 @@ public class BlockDataCyler implements DoubleActionBlockTool {
         if (block.getStates().keySet().isEmpty()) {
             player.printError("That block's data cannot be cycled!");
         } else {
-            Property currentProperty = selectedProperties.get(player.getUniqueId());
+            Property<?> currentProperty = selectedProperties.get(player.getUniqueId());
 
             if (currentProperty == null || (forward && block.getState(currentProperty) == null)) {
                 currentProperty = block.getStates().keySet().stream().findFirst().get();
@@ -79,7 +79,9 @@ public class BlockDataCyler implements DoubleActionBlockTool {
                 block.getState(currentProperty);
                 int index = currentProperty.getValues().indexOf(block.getState(currentProperty));
                 index = (index + 1) % currentProperty.getValues().size();
-                BlockState newBlock = block.with(currentProperty, currentProperty.getValues().get(index));
+                @SuppressWarnings("unchecked")
+                Property<Object> objProp = (Property<Object>) currentProperty;
+                BlockState newBlock = block.with(objProp, currentProperty.getValues().get(index));
 
                 try (EditSession editSession = session.createEditSession(player)) {
                     editSession.disableBuffering();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockReplacer.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockReplacer.java
@@ -30,7 +30,7 @@ import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.function.pattern.BlockPattern;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BlockState;
 
 /**
  * A mode that replaces one block.
@@ -73,7 +73,7 @@ public class BlockReplacer implements DoubleActionBlockTool {
 
     @Override
     public boolean actSecondary(Platform server, LocalConfiguration config, Player player, LocalSession session, com.sk89q.worldedit.util.Location clicked) {
-        BlockStateHolder targetBlock = player.getWorld().getBlock(clicked.toVector().toBlockPoint());
+        BlockState targetBlock = player.getWorld().getBlock(clicked.toVector().toBlockPoint());
 
         if (targetBlock != null) {
             pattern = new BlockPattern(targetBlock);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/LongRangeBuildTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/LongRangeBuildTool.java
@@ -29,7 +29,7 @@ import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Location;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
 
 /**
  * A tool that can place (or remove) blocks at a distance.
@@ -57,7 +57,7 @@ public class LongRangeBuildTool extends BrushTool implements DoubleActionTraceTo
         try (EditSession eS = session.createEditSession(player)) {
             eS.disableBuffering();
             BlockVector3 blockPoint = pos.toVector().toBlockPoint();
-            BlockStateHolder applied = secondary.apply(blockPoint);
+            BaseBlock applied = secondary.apply(blockPoint);
             if (applied.getBlockType().getMaterial().isAir()) {
                 eS.setBlock(blockPoint, secondary);
             } else {
@@ -78,7 +78,7 @@ public class LongRangeBuildTool extends BrushTool implements DoubleActionTraceTo
         try (EditSession eS = session.createEditSession(player)) {
             eS.disableBuffering();
             BlockVector3 blockPoint = pos.toVector().toBlockPoint();
-            BlockStateHolder applied = primary.apply(blockPoint);
+            BaseBlock applied = primary.apply(blockPoint);
             if (applied.getBlockType().getMaterial().isAir()) {
                 eS.setBlock(blockPoint, primary);
             } else {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/QueryTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/QueryTool.java
@@ -28,7 +28,7 @@ import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.World;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
 
 /**
  * Looks up information about a block.
@@ -46,7 +46,7 @@ public class QueryTool implements BlockTool {
         World world = (World) clicked.getExtent();
         EditSession editSession = session.createEditSession(player);
         BlockVector3 blockPoint = clicked.toVector().toBlockPoint();
-        BlockStateHolder block = editSession.getFullBlock(blockPoint);
+        BaseBlock block = editSession.getFullBlock(blockPoint);
 
         player.print("\u00A79@" + clicked.toVector() + ": " + "\u00A7e"
                 + block.getBlockType().getName() + "\u00A77" + " ("

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/GravityBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/GravityBrush.java
@@ -23,7 +23,7 @@ import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypes;
 
 import java.util.ArrayList;
@@ -44,10 +44,10 @@ public class GravityBrush implements Brush {
         for (double x = position.getBlockX() + size; x > position.getBlockX() - size; --x) {
             for (double z = position.getBlockZ() + size; z > position.getBlockZ() - size; --z) {
                 double y = startY;
-                final List<BlockStateHolder> blockTypes = new ArrayList<>();
+                final List<BlockState> blockTypes = new ArrayList<>();
                 for (; y > position.getBlockY() - size; --y) {
                     final BlockVector3 pt = BlockVector3.at(x, y, z);
-                    final BlockStateHolder block = editSession.getBlock(pt);
+                    final BlockState block = editSession.getBlock(pt);
                     if (!block.getBlockType().getMaterial().isAir()) {
                         blockTypes.add(block);
                         editSession.setBlock(pt, BlockTypes.AIR.getDefaultState());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
@@ -276,5 +276,5 @@ public interface Player extends Entity, Actor {
      * @param pos The position of the block
      * @param block The block to send, null to reset
      */
-    void sendFakeBlock(BlockVector3 pos, @Nullable BlockStateHolder block);
+    <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, @Nullable B block);
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/BlockFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/BlockFactory.java
@@ -22,11 +22,10 @@ package com.sk89q.worldedit.extension.factory;
 import com.sk89q.util.StringUtil;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.factory.parser.DefaultBlockParser;
-import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.internal.registry.AbstractFactory;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -38,7 +37,7 @@ import java.util.Set;
  * <p>Instances of this class can be taken from
  * {@link WorldEdit#getBlockFactory()}.</p>
  */
-public class BlockFactory extends AbstractFactory<BlockStateHolder> {
+public class BlockFactory extends AbstractFactory<BaseBlock> {
 
     /**
      * Create a new instance.
@@ -59,8 +58,8 @@ public class BlockFactory extends AbstractFactory<BlockStateHolder> {
      * @return a set of blocks
      * @throws InputParseException thrown in error with the input
      */
-    public Set<BlockStateHolder> parseFromListInput(String input, ParserContext context) throws InputParseException {
-        Set<BlockStateHolder> blocks = new HashSet<>();
+    public Set<BaseBlock> parseFromListInput(String input, ParserContext context) throws InputParseException {
+        Set<BaseBlock> blocks = new HashSet<>();
         String[] splits = input.split(",");
         for (String token : StringUtil.parseListInQuotes(splits, ',', '[', ']')) {
             blocks.add(parseFromInput(token, context));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlocksMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlocksMaskParser.java
@@ -28,7 +28,7 @@ import com.sk89q.worldedit.function.mask.BlockMask;
 import com.sk89q.worldedit.function.mask.Mask;
 import com.sk89q.worldedit.internal.registry.InputParser;
 import com.sk89q.worldedit.session.request.Request;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
 
 import java.util.Set;
 
@@ -48,7 +48,7 @@ public class BlocksMaskParser extends InputParser<Mask> {
         tempContext.setRestricted(false);
         tempContext.setPreferringWildcard(true);
         try {
-            Set<BlockStateHolder> holders = worldEdit.getBlockFactory().parseFromListInput(component, tempContext);
+            Set<BaseBlock> holders = worldEdit.getBlockFactory().parseFromListInput(component, tempContext);
             if (holders.isEmpty()) {
                 return null;
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
@@ -28,7 +28,7 @@ import com.sk89q.worldedit.function.pattern.BlockPattern;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.function.pattern.RandomPattern;
 import com.sk89q.worldedit.internal.registry.InputParser;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
 
 public class RandomPatternParser extends InputParser<Pattern> {
 
@@ -43,7 +43,7 @@ public class RandomPatternParser extends InputParser<Pattern> {
 
         String[] splits = input.split(",");
         for (String token : StringUtil.parseListInQuotes(splits, ',', '[', ']')) {
-            BlockStateHolder block;
+            BaseBlock block;
 
             double chance;
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -170,7 +170,7 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
                 ++spots;
                 if (spots == 2) {
                     final BlockVector3 platform = BlockVector3.at(x, y - 2, z);
-                    final BlockStateHolder block = world.getBlock(platform);
+                    final BlockState block = world.getBlock(platform);
                     final com.sk89q.worldedit.world.block.BlockType type = block.getBlockType();
 
                     // Don't get put in lava!
@@ -212,7 +212,7 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
                 // stand upon
                 while (y >= 0) {
                     final BlockVector3 platform = BlockVector3.at(x, y, z);
-                    final BlockStateHolder block = world.getBlock(platform);
+                    final BlockState block = world.getBlock(platform);
                     final BlockType type = block.getBlockType();
 
                     // Don't want to end up in lava
@@ -500,7 +500,7 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     }
 
     @Override
-    public void sendFakeBlock(BlockVector3 pos, BlockStateHolder block) {
+    public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, B block) {
 
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlayerProxy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlayerProxy.java
@@ -169,7 +169,7 @@ class PlayerProxy extends AbstractPlayerActor {
     }
 
     @Override
-    public void sendFakeBlock(BlockVector3 pos, BlockStateHolder block) {
+    public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, B block) {
         basePlayer.sendFakeBlock(pos, block);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractDelegateExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractDelegateExtent.java
@@ -76,7 +76,7 @@ public abstract class AbstractDelegateExtent implements Extent {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 location, BlockStateHolder block) throws WorldEditException {
+    public <T extends BlockStateHolder<T>> boolean setBlock(BlockVector3 location, T block) throws WorldEditException {
         return extent.setBlock(location, block);
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/ChangeSetExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/ChangeSetExtent.java
@@ -59,7 +59,7 @@ public class ChangeSetExtent extends AbstractDelegateExtent {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 location, BlockStateHolder block) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 location, B block) throws WorldEditException {
         BaseBlock previous = getFullBlock(location);
         changeSet.add(new BlockChange(location, previous, block));
         return super.setBlock(location, block);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/MaskingExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/MaskingExtent.java
@@ -65,7 +65,7 @@ public class MaskingExtent extends AbstractDelegateExtent {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 location, BlockStateHolder block) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 location, B block) throws WorldEditException {
         return mask.test(location) && super.setBlock(location, block);
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/NullExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/NullExtent.java
@@ -87,7 +87,7 @@ public class NullExtent implements Extent {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 position, BlockStateHolder block) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block) throws WorldEditException {
         return false;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/OutputExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/OutputExtent.java
@@ -50,7 +50,7 @@ public interface OutputExtent {
      * @return true if the block was successfully set (return value may not be accurate)
      * @throws WorldEditException thrown on an error
      */
-    boolean setBlock(BlockVector3 position, BlockStateHolder block) throws WorldEditException;
+    <T extends BlockStateHolder<T>> boolean setBlock(BlockVector3 position, T block) throws WorldEditException;
 
     /**
      * Set the biome.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/buffer/ForgetfulExtentBuffer.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/buffer/ForgetfulExtentBuffer.java
@@ -31,6 +31,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.AbstractRegion;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionOperationException;
+import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockTypes;
 
@@ -47,7 +48,7 @@ import java.util.Map;
  */
 public class ForgetfulExtentBuffer extends AbstractDelegateExtent implements Pattern {
 
-    private final Map<BlockVector3, BlockStateHolder> buffer = new LinkedHashMap<>();
+    private final Map<BlockVector3, BaseBlock> buffer = new LinkedHashMap<>();
     private final Mask mask;
     private BlockVector3 min = null;
     private BlockVector3 max = null;
@@ -76,7 +77,7 @@ public class ForgetfulExtentBuffer extends AbstractDelegateExtent implements Pat
     }
 
     @Override
-    public boolean setBlock(BlockVector3 location, BlockStateHolder block) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 location, B block) throws WorldEditException {
         // Update minimum
         if (min == null) {
             min = location;
@@ -93,7 +94,7 @@ public class ForgetfulExtentBuffer extends AbstractDelegateExtent implements Pat
 
         BlockVector3 blockVector = location;
         if (mask.test(blockVector)) {
-            buffer.put(blockVector, block);
+            buffer.put(blockVector, block.toBaseBlock());
             return true;
         } else {
             return getExtent().setBlock(location, block);
@@ -101,12 +102,12 @@ public class ForgetfulExtentBuffer extends AbstractDelegateExtent implements Pat
     }
 
     @Override
-    public BlockStateHolder apply(BlockVector3 pos) {
-        BlockStateHolder block = buffer.get(pos);
+    public BaseBlock apply(BlockVector3 pos) {
+        BaseBlock block = buffer.get(pos);
         if (block != null) {
             return block;
         } else {
-            return BlockTypes.AIR.getDefaultState();
+            return BlockTypes.AIR.getDefaultState().toBaseBlock();
         }
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/BlockArrayClipboard.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/BlockArrayClipboard.java
@@ -49,7 +49,7 @@ public class BlockArrayClipboard implements Clipboard {
 
     private final Region region;
     private BlockVector3 origin;
-    private final BlockStateHolder[][][] blocks;
+    private final BaseBlock[][][] blocks;
     private final List<ClipboardEntity> entities = new ArrayList<>();
 
     /**
@@ -65,7 +65,7 @@ public class BlockArrayClipboard implements Clipboard {
         this.origin = region.getMinimumPoint();
 
         BlockVector3 dimensions = getDimensions();
-        blocks = new BlockStateHolder[dimensions.getBlockX()][dimensions.getBlockY()][dimensions.getBlockZ()];
+        blocks = new BaseBlock[dimensions.getBlockX()][dimensions.getBlockY()][dimensions.getBlockZ()];
     }
 
     @Override
@@ -126,7 +126,7 @@ public class BlockArrayClipboard implements Clipboard {
     public BlockState getBlock(BlockVector3 position) {
         if (region.contains(position)) {
             BlockVector3 v = position.subtract(region.getMinimumPoint());
-            BlockStateHolder block = blocks[v.getBlockX()][v.getBlockY()][v.getBlockZ()];
+            BaseBlock block = blocks[v.getBlockX()][v.getBlockY()][v.getBlockZ()];
             if (block != null) {
                 return block.toImmutableState();
             }
@@ -139,9 +139,9 @@ public class BlockArrayClipboard implements Clipboard {
     public BaseBlock getFullBlock(BlockVector3 position) {
         if (region.contains(position)) {
             BlockVector3 v = position.subtract(region.getMinimumPoint());
-            BlockStateHolder block = blocks[v.getBlockX()][v.getBlockY()][v.getBlockZ()];
+            BaseBlock block = blocks[v.getBlockX()][v.getBlockY()][v.getBlockZ()];
             if (block != null) {
-                return block.toBaseBlock();
+                return block;
             }
         }
 
@@ -149,10 +149,10 @@ public class BlockArrayClipboard implements Clipboard {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 position, BlockStateHolder block) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block) throws WorldEditException {
         if (region.contains(position)) {
             BlockVector3 v = position.subtract(region.getMinimumPoint());
-            blocks[v.getBlockX()][v.getBlockY()][v.getBlockZ()] = block;
+            blocks[v.getBlockX()][v.getBlockY()][v.getBlockZ()] = block.toBaseBlock();
             return true;
         } else {
             return false;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/NBTCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/NBTCompatibilityHandler.java
@@ -25,6 +25,6 @@ import com.sk89q.worldedit.world.block.BlockStateHolder;
 import java.util.Map;
 
 public interface NBTCompatibilityHandler {
-    boolean isAffectedBlock(BlockStateHolder block);
-    void updateNBT(BlockStateHolder block, Map<String, Tag> values);
+    <B extends BlockStateHolder<B>> boolean isAffectedBlock(B block);
+    <B extends BlockStateHolder<B>> void updateNBT(B block, Map<String, Tag> values);
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/SignCompatibilityHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/legacycompat/SignCompatibilityHandler.java
@@ -32,13 +32,14 @@ import com.sk89q.worldedit.world.block.BlockTypes;
 import java.util.Map;
 
 public class SignCompatibilityHandler implements NBTCompatibilityHandler {
+
     @Override
-    public boolean isAffectedBlock(BlockStateHolder block) {
+    public <B extends BlockStateHolder<B>> boolean isAffectedBlock(B block) {
         return block.getBlockType() == BlockTypes.SIGN || block.getBlockType() == BlockTypes.WALL_SIGN;
     }
 
     @Override
-    public void updateNBT(BlockStateHolder block, Map<String, Tag> values) {
+    public <B extends BlockStateHolder<B>> void updateNBT(B block, Map<String, Tag> values) {
         for (int i = 0; i < 4; ++i) {
             String key = "Text" + (i + 1);
             Tag value = values.get(key);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/inventory/BlockBagExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/inventory/BlockBagExtent.java
@@ -82,7 +82,7 @@ public class BlockBagExtent extends AbstractDelegateExtent {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 position, BlockStateHolder block) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block) throws WorldEditException {
         if (blockBag != null) {
             BlockState existing = getExtent().getBlock(position);
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/reorder/ChunkBatchingExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/reorder/ChunkBatchingExtent.java
@@ -77,7 +77,7 @@ public class ChunkBatchingExtent extends AbstractDelegateExtent {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 location, BlockStateHolder block) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 location, B block) throws WorldEditException {
         if (!enabled) {
             return getExtent().setBlock(location, block);
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/reorder/MultiStageReorder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/reorder/MultiStageReorder.java
@@ -27,6 +27,7 @@ import com.sk89q.worldedit.function.operation.OperationQueue;
 import com.sk89q.worldedit.function.operation.SetLocatedBlocks;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.collection.LocatedBlockList;
+import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockCategories;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
@@ -201,12 +202,12 @@ public class MultiStageReorder extends AbstractDelegateExtent implements Reorder
      * @param block The block
      * @return The priority
      */
-    private PlacementPriority getPlacementPriority(BlockStateHolder block) {
+    private <B extends BlockStateHolder<B>> PlacementPriority getPlacementPriority(B block) {
         return priorityMap.getOrDefault(block.getBlockType(), PlacementPriority.FIRST);
     }
 
     @Override
-    public boolean setBlock(BlockVector3 location, BlockStateHolder block) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 location, B block) throws WorldEditException {
         if (!enabled) {
             return super.setBlock(location, block);
         }
@@ -216,7 +217,7 @@ public class MultiStageReorder extends AbstractDelegateExtent implements Reorder
         PlacementPriority srcPriority = getPlacementPriority(existing);
 
         if (srcPriority != PlacementPriority.FIRST) {
-            BlockStateHolder replacement = block.getBlockType().getMaterial().isAir() ? block : BlockTypes.AIR.getDefaultState();
+            BaseBlock replacement = (block.getBlockType().getMaterial().isAir() ? block : BlockTypes.AIR.getDefaultState()).toBaseBlock();
 
             switch (srcPriority) {
                 case FINAL:

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/validation/BlockChangeLimiter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/validation/BlockChangeLimiter.java
@@ -77,7 +77,7 @@ public class BlockChangeLimiter extends AbstractDelegateExtent {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 location, BlockStateHolder block) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 location, B block) throws WorldEditException {
         if (limit >= 0) {
             if (count >= limit) {
                 throw new MaxChangedBlocksException(limit);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/validation/DataValidatorExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/validation/DataValidatorExtent.java
@@ -49,7 +49,7 @@ public class DataValidatorExtent extends AbstractDelegateExtent {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 location, BlockStateHolder block) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 location, B block) throws WorldEditException {
         final int y = location.getBlockY();
         final BlockType type = block.getBlockType();
         if (y < 0 || y > world.getMaxY()) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/BlockQuirkExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/BlockQuirkExtent.java
@@ -51,7 +51,7 @@ public class BlockQuirkExtent extends AbstractDelegateExtent {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 position, BlockStateHolder block) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block) throws WorldEditException {
         BlockType existing = getExtent().getBlock(position).getBlockType();
 
         if (existing.getMaterial().hasContainer()) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/ChunkLoadingExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/ChunkLoadingExtent.java
@@ -61,7 +61,7 @@ public class ChunkLoadingExtent extends AbstractDelegateExtent {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 location, BlockStateHolder block) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 location, B block) throws WorldEditException {
         world.checkLoadedChunk(location);
         return super.setBlock(location, block);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/FastModeExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/FastModeExtent.java
@@ -96,7 +96,7 @@ public class FastModeExtent extends AbstractDelegateExtent {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 location, BlockStateHolder block) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 location, B block) throws WorldEditException {
         if (enabled || postEditSimulation) {
             dirtyChunks.add(BlockVector2.at(location.getBlockX() >> 4, location.getBlockZ() >> 4));
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/SurvivalModeExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/SurvivalModeExtent.java
@@ -79,7 +79,7 @@ public class SurvivalModeExtent extends AbstractDelegateExtent {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 location, BlockStateHolder block) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 location, B block) throws WorldEditException {
         if (toolUse && block.getBlockType().getMaterial().isAir()) {
             world.simulateBlockMine(location);
             return true;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/block/BlockDistributionCounter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/block/BlockDistributionCounter.java
@@ -25,7 +25,6 @@ import com.sk89q.worldedit.function.RegionFunction;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Countable;
 import com.sk89q.worldedit.world.block.BlockState;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,27 +35,27 @@ import java.util.Map;
 public class BlockDistributionCounter implements RegionFunction {
 
     private Extent extent;
-    private boolean fuzzy;
+    private boolean separateStates;
 
-    private List<Countable<BlockStateHolder>> distribution = new ArrayList<>();
-    private Map<BlockStateHolder, Countable<BlockStateHolder>> map = new HashMap<>();
+    private List<Countable<BlockState>> distribution = new ArrayList<>();
+    private Map<BlockState, Countable<BlockState>> map = new HashMap<>();
 
-    public BlockDistributionCounter(Extent extent, boolean fuzzy) {
+    public BlockDistributionCounter(Extent extent, boolean separateStates) {
         this.extent = extent;
-        this.fuzzy = fuzzy;
+        this.separateStates = separateStates;
     }
 
     @Override
     public boolean apply(BlockVector3 position) throws WorldEditException {
-        BlockStateHolder blk = extent.getBlock(position);
-        if (fuzzy) {
-            blk = ((BlockState) blk).toFuzzy();
+        BlockState blk = extent.getBlock(position);
+        if (!separateStates) {
+            blk = blk.getBlockType().getDefaultState();
         }
 
         if (map.containsKey(blk)) {
             map.get(blk).increment();
         } else {
-            Countable<BlockStateHolder> c = new Countable<>(blk, 1);
+            Countable<BlockState> c = new Countable<>(blk, 1);
             map.put(blk, c);
             distribution.add(c);
         }
@@ -69,7 +68,7 @@ public class BlockDistributionCounter implements RegionFunction {
      *
      * @return The distribution
      */
-    public List<Countable<BlockStateHolder>> getDistribution() {
+    public List<Countable<BlockState>> getDistribution() {
         Collections.sort(distribution);
         Collections.reverse(distribution);
         return this.distribution;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/generator/FloraGenerator.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/generator/FloraGenerator.java
@@ -26,7 +26,7 @@ import com.sk89q.worldedit.function.pattern.BlockPattern;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.function.pattern.RandomPattern;
 import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypes;
 
 /**
@@ -104,7 +104,7 @@ public class FloraGenerator implements RegionFunction {
 
     @Override
     public boolean apply(BlockVector3 position) throws WorldEditException {
-        BlockStateHolder block = editSession.getBlock(position);
+        BlockState block = editSession.getBlock(position);
 
         if (block.getBlockType() == BlockTypes.GRASS_BLOCK) {
             editSession.setBlock(position.add(0, 1, 0), temperatePattern.apply(position));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/generator/ForestGenerator.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/generator/ForestGenerator.java
@@ -24,7 +24,7 @@ import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.function.RegionFunction;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.TreeGenerator;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
 
@@ -50,7 +50,7 @@ public class ForestGenerator implements RegionFunction {
 
     @Override
     public boolean apply(BlockVector3 position) throws WorldEditException {
-        BlockStateHolder block = editSession.getBlock(position);
+        BlockState block = editSession.getBlock(position);
         BlockType t = block.getBlockType();
 
         if (t == BlockTypes.GRASS_BLOCK || t == BlockTypes.DIRT) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/generator/GardenPatchGenerator.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/generator/GardenPatchGenerator.java
@@ -198,7 +198,7 @@ public class GardenPatchGenerator implements RegionFunction {
      * @return if block was changed
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
-    private static boolean setBlockIfAir(EditSession session, BlockVector3 position, BlockStateHolder block) throws MaxChangedBlocksException {
+    private static <B extends BlockStateHolder<B>> boolean setBlockIfAir(EditSession session, BlockVector3 position, B block) throws MaxChangedBlocksException {
         return session.getBlock(position).getBlockType().getMaterial().isAir() && session.setBlock(position, block);
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BlockMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BlockMask.java
@@ -23,7 +23,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.block.BlockState;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -41,7 +42,7 @@ import javax.annotation.Nullable;
  */
 public class BlockMask extends AbstractExtentMask {
 
-    private final Set<BlockStateHolder> blocks = new HashSet<>();
+    private final Set<BaseBlock> blocks = new HashSet<>();
 
     /**
      * Create a new block mask.
@@ -49,7 +50,7 @@ public class BlockMask extends AbstractExtentMask {
      * @param extent the extent
      * @param blocks a list of blocks to match
      */
-    public BlockMask(Extent extent, Collection<BlockStateHolder> blocks) {
+    public BlockMask(Extent extent, Collection<BaseBlock> blocks) {
         super(extent);
         checkNotNull(blocks);
         this.blocks.addAll(blocks);
@@ -61,7 +62,7 @@ public class BlockMask extends AbstractExtentMask {
      * @param extent the extent
      * @param block an array of blocks to match
      */
-    public BlockMask(Extent extent, BlockStateHolder... block) {
+    public BlockMask(Extent extent, BaseBlock... block) {
         this(extent, Arrays.asList(checkNotNull(block)));
     }
 
@@ -70,7 +71,7 @@ public class BlockMask extends AbstractExtentMask {
      *
      * @param blocks a list of blocks
      */
-    public void add(Collection<BlockStateHolder> blocks) {
+    public void add(Collection<BaseBlock> blocks) {
         checkNotNull(blocks);
         this.blocks.addAll(blocks);
     }
@@ -80,7 +81,7 @@ public class BlockMask extends AbstractExtentMask {
      *
      * @param block an array of blocks
      */
-    public void add(BlockStateHolder... block) {
+    public void add(BaseBlock... block) {
         add(Arrays.asList(checkNotNull(block)));
     }
 
@@ -89,14 +90,14 @@ public class BlockMask extends AbstractExtentMask {
      *
      * @return a list of blocks
      */
-    public Collection<BlockStateHolder> getBlocks() {
+    public Collection<BaseBlock> getBlocks() {
         return blocks;
     }
 
     @Override
     public boolean test(BlockVector3 vector) {
-        BlockStateHolder block = getExtent().getBlock(vector);
-        for (BlockStateHolder testBlock : blocks) {
+        BlockState block = getExtent().getBlock(vector);
+        for (BaseBlock testBlock : blocks) {
             if (testBlock.equalsFuzzy(block)) {
                 return true;
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/BlockPattern.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/BlockPattern.java
@@ -30,14 +30,14 @@ import com.sk89q.worldedit.world.block.BlockStateHolder;
  */
 public class BlockPattern extends AbstractPattern {
 
-    private BlockStateHolder block;
+    private BaseBlock block;
 
     /**
      * Create a new pattern with the given block.
      *
      * @param block the block
      */
-    public BlockPattern(BlockStateHolder block) {
+    public BlockPattern(BlockStateHolder<?> block) {
         setBlock(block);
     }
 
@@ -46,7 +46,7 @@ public class BlockPattern extends AbstractPattern {
      *
      * @return the block that is always returned
      */
-    public BlockStateHolder getBlock() {
+    public BaseBlock getBlock() {
         return block;
     }
 
@@ -55,13 +55,13 @@ public class BlockPattern extends AbstractPattern {
      *
      * @param block the block
      */
-    public void setBlock(BlockStateHolder block) {
+    public void setBlock(BlockStateHolder<?> block) {
         checkNotNull(block);
-        this.block = block;
+        this.block = block.toBaseBlock();
     }
 
     @Override
-    public BlockStateHolder apply(BlockVector3 position) {
+    public BaseBlock apply(BlockVector3 position) {
         return block;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/ClipboardPattern.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/ClipboardPattern.java
@@ -23,7 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
 
 /**
  * A pattern that reads from {@link Clipboard}.
@@ -45,7 +45,7 @@ public class ClipboardPattern extends AbstractPattern {
     }
 
     @Override
-    public BlockStateHolder apply(BlockVector3 position) {
+    public BaseBlock apply(BlockVector3 position) {
         int xp = Math.abs(position.getBlockX()) % size.getBlockX();
         int yp = Math.abs(position.getBlockY()) % size.getBlockY();
         int zp = Math.abs(position.getBlockZ()) % size.getBlockZ();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/Pattern.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/Pattern.java
@@ -20,6 +20,7 @@
 package com.sk89q.worldedit.function.pattern;
 
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 
 /**
@@ -33,6 +34,6 @@ public interface Pattern {
      * @param position the position
      * @return a block
      */
-    BlockStateHolder apply(BlockVector3 position);
+    BaseBlock apply(BlockVector3 position);
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/RandomPattern.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/RandomPattern.java
@@ -22,7 +22,7 @@ package com.sk89q.worldedit.function.pattern;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +53,7 @@ public class RandomPattern extends AbstractPattern {
     }
 
     @Override
-    public BlockStateHolder apply(BlockVector3 position) {
+    public BaseBlock apply(BlockVector3 position) {
         double r = random.nextDouble();
         double offset = 0;
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/RepeatingExtentPattern.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/RepeatingExtentPattern.java
@@ -23,7 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
 
 /**
  * Returns the blocks from {@link Extent}, repeating when out of bounds.
@@ -83,7 +83,7 @@ public class RepeatingExtentPattern extends AbstractPattern {
     }
 
     @Override
-    public BlockStateHolder apply(BlockVector3 position) {
+    public BaseBlock apply(BlockVector3 position) {
         BlockVector3 base = position.add(offset);
         BlockVector3 size = extent.getMaximumPoint().subtract(extent.getMinimumPoint()).add(1, 1, 1);
         int x = base.getBlockX() % size.getBlockX();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/history/change/BlockChange.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/history/change/BlockChange.java
@@ -25,6 +25,7 @@ import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.history.UndoContext;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 
 /**
@@ -37,8 +38,8 @@ import com.sk89q.worldedit.world.block.BlockStateHolder;
 public class BlockChange implements Change {
 
     private final BlockVector3 position;
-    private final BlockStateHolder previous;
-    private final BlockStateHolder current;
+    private final BaseBlock previous;
+    private final BaseBlock current;
 
     /**
      * Create a new block change.
@@ -47,13 +48,13 @@ public class BlockChange implements Change {
      * @param previous the previous block
      * @param current the current block
      */
-    public BlockChange(BlockVector3 position, BlockStateHolder previous, BlockStateHolder current) {
+    public <BP extends BlockStateHolder<BP>, BC extends BlockStateHolder<BC>> BlockChange(BlockVector3 position, BP previous, BC current) {
         checkNotNull(position);
         checkNotNull(previous);
         checkNotNull(current);
         this.position = position;
-        this.previous = previous;
-        this.current = current;
+        this.previous = previous.toBaseBlock();
+        this.current = current.toBaseBlock();
     }
 
     /**
@@ -70,7 +71,7 @@ public class BlockChange implements Change {
      *
      * @return the previous block
      */
-    public BlockStateHolder getPrevious() {
+    public BaseBlock getPrevious() {
         return previous;
     }
 
@@ -79,7 +80,7 @@ public class BlockChange implements Change {
      *
      * @return the current block
      */
-    public BlockStateHolder getCurrent() {
+    public BaseBlock getCurrent() {
         return current;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/WorldEditBinding.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/WorldEditBinding.java
@@ -172,7 +172,7 @@ public class WorldEditBinding extends BindingHelper {
     @BindingMatch(type = {BaseBlock.class, BlockState.class, BlockStateHolder.class},
                   behavior = BindingBehavior.CONSUMES,
                   consumedCount = 1)
-    public BlockStateHolder getBaseBlock(ArgumentStack context) throws ParameterException, WorldEditException {
+    public BaseBlock getBaseBlock(ArgumentStack context) throws ParameterException, WorldEditException {
         Actor actor = context.getContext().getLocals().get(Actor.class);
         ParserContext parserContext = new ParserContext();
         parserContext.setActor(context.getContext().getLocals().get(Actor.class));
@@ -311,19 +311,6 @@ public class WorldEditBinding extends BindingHelper {
     public BaseBiome getBiomeType(ArgumentStack context) throws ParameterException, WorldEditException {
         String input = context.next();
         if (input != null) {
-            Actor actor = context.getContext().getLocals().get(Actor.class);
-            World world;
-            if (actor instanceof Entity) {
-                Extent extent = ((Entity) actor).getExtent();
-                if (extent instanceof World) {
-                    world = (World) extent;
-                } else {
-                    throw new ParameterException("A world is required.");
-                }
-            } else {
-                throw new ParameterException("An entity is required.");
-            }
-
             BiomeRegistry biomeRegistry = WorldEdit.getInstance().getPlatformManager()
                     .queryCapability(Capability.GAME_HOOKS).getRegistries().getBiomeRegistry();
             List<BaseBiome> knownBiomes = biomeRegistry.getBiomes();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/AbstractFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/AbstractFactory.java
@@ -21,7 +21,6 @@ package com.sk89q.worldedit.internal.registry;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.collect.Lists;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.NoMatchException;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionIntersection.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionIntersection.java
@@ -131,7 +131,7 @@ public class RegionIntersection extends AbstractRegion {
         return false;
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked"})
     @Override
     public Iterator<BlockVector3> iterator() {
         Iterator<BlockVector3>[] iterators = (Iterator<BlockVector3>[]) new Iterator[regions.size()];

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/EllipsoidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/EllipsoidRegionSelector.java
@@ -119,7 +119,7 @@ public class EllipsoidRegionSelector implements RegionSelector, CUIRegion {
 
     @Override
     public boolean selectPrimary(BlockVector3 position, SelectorLimits limits) {
-        if (position.equals(region.getCenter()) && region.getRadius().lengthSq() == 0) {
+        if (position.equals(region.getCenter().toBlockPoint()) && region.getRadius().lengthSq() == 0) {
             return false;
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/ArbitraryShape.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/ArbitraryShape.java
@@ -24,7 +24,7 @@ import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
 
 /**
  * Generates solid and hollow shapes according to materials returned by the
@@ -51,7 +51,7 @@ public abstract class ArbitraryShape {
      * @param defaultMaterial The material returned by the pattern for the current block.
      * @return material to place or null to not place anything.
      */
-    protected abstract BlockStateHolder getMaterial(int x, int y, int z, BlockStateHolder defaultMaterial);
+    protected abstract BaseBlock getMaterial(int x, int y, int z, BaseBlock defaultMaterial);
 
     /**
      * Generates the shape.
@@ -71,7 +71,7 @@ public abstract class ArbitraryShape {
             int z = position.getBlockZ();
 
             if (!hollow) {
-                final BlockStateHolder material = getMaterial(x, y, z, pattern.apply(position));
+                BaseBlock material = getMaterial(x, y, z, pattern.apply(position));
                 if (material != null && editSession.setBlock(position, material)) {
                     ++affected;
                 }
@@ -79,7 +79,7 @@ public abstract class ArbitraryShape {
                 continue;
             }
 
-            final BlockStateHolder material = getMaterial(x, y, z, pattern.apply(position));
+            BaseBlock material = getMaterial(x, y, z, pattern.apply(position));
             if (material == null) {
                 continue;
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/RegionShape.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/RegionShape.java
@@ -21,7 +21,7 @@ package com.sk89q.worldedit.regions.shape;
 
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
 
 /**
  * Generates solid and hollow shapes according to materials returned by the
@@ -34,7 +34,7 @@ public class RegionShape extends ArbitraryShape {
     }
 
     @Override
-    protected BlockStateHolder getMaterial(int x, int y, int z, BlockStateHolder defaultMaterial) {
+    protected BaseBlock getMaterial(int x, int y, int z, BaseBlock defaultMaterial) {
         if (!this.extent.contains(BlockVector3.at(x, y, z))) {
             return null;
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/registry/state/AbstractProperty.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/registry/state/AbstractProperty.java
@@ -66,6 +66,6 @@ public abstract class AbstractProperty<T> implements Property<T> {
         if (!(obj instanceof Property)) {
             return false;
         }
-        return getName().equals(((Property) obj).getName());
+        return getName().equals(((Property<?>) obj).getName());
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/scripting/CraftScriptContext.java
@@ -32,7 +32,7 @@ import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.util.io.file.FilenameException;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -157,7 +157,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
      * @throws UnknownItemException
      * @throws DisallowedItemException
      */
-    public BlockStateHolder getBlock(String input, boolean allAllowed) throws WorldEditException {
+    public BaseBlock getBlock(String input, boolean allAllowed) throws WorldEditException {
         ParserContext context = new ParserContext();
         context.setActor(player);
         context.setWorld(player.getWorld());
@@ -176,7 +176,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
      * @throws UnknownItemException
      * @throws DisallowedItemException
      */
-    public BlockStateHolder getBlock(String id) throws WorldEditException {
+    public BaseBlock getBlock(String id) throws WorldEditException {
         return getBlock(id, false);
     }
 
@@ -205,7 +205,7 @@ public class CraftScriptContext extends CraftScriptEnvironment {
      * @throws UnknownItemException 
      * @throws DisallowedItemException 
      */
-    public Set<BlockStateHolder> getBlocks(String list, boolean allBlocksAllowed) throws WorldEditException {
+    public Set<BaseBlock> getBlocks(String list, boolean allBlocksAllowed) throws WorldEditException {
         ParserContext context = new ParserContext();
         context.setActor(player);
         context.setWorld(player.getWorld());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/FileDialogUtil.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/FileDialogUtil.java
@@ -85,7 +85,7 @@ public final class FileDialogUtil {
             if (index == -1 || index == path.length() - 1) {
                 return false;
             } else {
-                return exts.contains(path.indexOf(index + 1));
+                return exts.contains(path.substring(index + 1));
             }
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/LocatedBlock.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/LocatedBlock.java
@@ -22,7 +22,7 @@ package com.sk89q.worldedit.util;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
 
 import java.util.Objects;
 
@@ -32,9 +32,9 @@ import java.util.Objects;
 public final class LocatedBlock {
 
     private final BlockVector3 location;
-    private final BlockStateHolder block;
+    private final BaseBlock block;
 
-    public LocatedBlock(BlockVector3 location, BlockStateHolder block) {
+    public LocatedBlock(BlockVector3 location, BaseBlock block) {
         this.location = checkNotNull(location);
         this.block = checkNotNull(block);
     }
@@ -43,7 +43,7 @@ public final class LocatedBlock {
         return location;
     }
 
-    public BlockStateHolder getBlock() {
+    public BaseBlock getBlock() {
         return block;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/TreeGenerator.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/TreeGenerator.java
@@ -250,7 +250,7 @@ public class TreeGenerator {
      * @return whether a block was changed
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
-    private static boolean setChanceBlockIfAir(EditSession session, BlockVector3 position, BlockStateHolder block, double probability)
+    private static <B extends BlockStateHolder<B>> boolean setChanceBlockIfAir(EditSession session, BlockVector3 position, B block, double probability)
             throws MaxChangedBlocksException {
         return Math.random() <= probability && setBlockIfAir(session, position, block);
     }
@@ -263,7 +263,7 @@ public class TreeGenerator {
      * @return if block was changed
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
-    private static boolean setBlockIfAir(EditSession session, BlockVector3 position, BlockStateHolder block) throws MaxChangedBlocksException {
+    private static <B extends BlockStateHolder<B>> boolean setBlockIfAir(EditSession session, BlockVector3 position, B block) throws MaxChangedBlocksException {
         return session.getBlock(position).getBlockType().getMaterial().isAir() && session.setBlock(position, block);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/collection/LocatedBlockList.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/collection/LocatedBlockList.java
@@ -51,8 +51,8 @@ public class LocatedBlockList implements Iterable<LocatedBlock> {
         list.add(setBlockCall);
     }
 
-    public void add(BlockVector3 location, BlockStateHolder block) {
-        add(new LocatedBlock(location, block));
+    public <B extends BlockStateHolder<B>> void add(BlockVector3 location, B block) {
+        add(new LocatedBlock(location, block.toBaseBlock()));
     }
 
     public int size() {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
@@ -52,7 +52,7 @@ public abstract class AbstractWorld implements World {
     }
 
     @Override
-    public final boolean setBlock(BlockVector3 pt, BlockStateHolder block) throws WorldEditException {
+    public final <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 pt, B block) throws WorldEditException {
         return setBlock(pt, block, true);
     }
 
@@ -138,6 +138,7 @@ public abstract class AbstractWorld implements World {
             this.priority = priority;
         }
 
+        @SuppressWarnings("deprecation")
         public void play() {
             playEffect(position, 2001, blockType.getLegacyId());
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/NullWorld.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/NullWorld.java
@@ -60,7 +60,7 @@ public class NullWorld extends AbstractWorld {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 position, BlockStateHolder block, boolean notifyAndLight) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block, boolean notifyAndLight) throws WorldEditException {
         return false;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
@@ -38,8 +38,6 @@ import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.weather.WeatherType;
 
-import java.util.Vector;
-
 /**
  * Represents a world (dimension).
  */
@@ -96,7 +94,7 @@ public interface World extends Extent {
      * @param notifyAndLight true to to notify and light
      * @return true if the block was successfully set (return value may not be accurate)
      */
-    boolean setBlock(BlockVector3 position, BlockStateHolder block, boolean notifyAndLight) throws WorldEditException;
+    <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block, boolean notifyAndLight) throws WorldEditException;
 
     /**
      * Notifies the simulation that the block at the given location has

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
@@ -135,7 +135,7 @@ public class BaseBlock implements BlockStateHolder<BaseBlock>, TileEntityBlock {
     public boolean equals(Object o) {
         if (!(o instanceof BaseBlock)) {
             if (!hasNbtData() && o instanceof BlockStateHolder) {
-                return Objects.equals(toImmutableState(), ((BlockStateHolder) o).toImmutableState());
+                return Objects.equals(toImmutableState(), ((BlockStateHolder<?>) o).toImmutableState());
             }
             return false;
         }
@@ -152,7 +152,7 @@ public class BaseBlock implements BlockStateHolder<BaseBlock>, TileEntityBlock {
      * @return true if equal
      */
     @Override
-    public boolean equalsFuzzy(BlockStateHolder o) {
+    public boolean equalsFuzzy(BlockStateHolder<?> o) {
         return this.toImmutableState().equalsFuzzy(o);
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockCategory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockCategory.java
@@ -52,7 +52,7 @@ public class BlockCategory extends Category<BlockType> {
      * @param blockStateHolder The blockstateholder
      * @return If it's a part of this category
      */
-    public boolean contains(BlockStateHolder blockStateHolder) {
+    public <B extends BlockStateHolder<B>> boolean contains(B blockStateHolder) {
         return this.getAll().contains(blockStateHolder.getBlockType());
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockState.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockState.java
@@ -74,11 +74,11 @@ public class BlockState implements BlockStateHolder<BlockState> {
 
     static Map<Map<Property<?>, Object>, BlockState> generateStateMap(BlockType blockType) {
         Map<Map<Property<?>, Object>, BlockState> stateMap = new LinkedHashMap<>();
-        List<? extends Property> properties = blockType.getProperties();
+        List<? extends Property<?>> properties = blockType.getProperties();
 
         if (!properties.isEmpty()) {
             List<List<Object>> separatedValues = Lists.newArrayList();
-            for (Property prop : properties) {
+            for (Property<?> prop : properties) {
                 List<Object> vals = Lists.newArrayList();
                 vals.addAll(prop.getValues());
                 separatedValues.add(vals);
@@ -113,7 +113,7 @@ public class BlockState implements BlockStateHolder<BlockState> {
         final Table<Property<?>, Object, BlockState> states = HashBasedTable.create();
 
         for(final Map.Entry<Property<?>, Object> entry : this.values.entrySet()) {
-            final Property property = entry.getKey();
+            final Property<Object> property = (Property<Object>) entry.getKey();
 
             property.getValues().forEach(value -> {
                 if(value != entry.getValue()) {
@@ -167,7 +167,7 @@ public class BlockState implements BlockStateHolder<BlockState> {
     }
 
     @Override
-    public boolean equalsFuzzy(BlockStateHolder o) {
+    public boolean equalsFuzzy(BlockStateHolder<?> o) {
         if (this == o) {
             // Added a reference equality check for
             return true;
@@ -176,19 +176,19 @@ public class BlockState implements BlockStateHolder<BlockState> {
             return false;
         }
 
-        Set<Property> differingProperties = new HashSet<>();
+        Set<Property<?>> differingProperties = new HashSet<>();
         for (Object state : o.getStates().keySet()) {
-            if (getState((Property) state) == null) {
-                differingProperties.add((Property) state);
+            if (getState((Property<?>) state) == null) {
+                differingProperties.add((Property<?>) state);
             }
         }
-        for (Property property : getStates().keySet()) {
+        for (Property<?> property : getStates().keySet()) {
             if (o.getState(property) == null) {
                 differingProperties.add(property);
             }
         }
 
-        for (Property property : getStates().keySet()) {
+        for (Property<?> property : getStates().keySet()) {
             if (differingProperties.contains(property)) {
                 continue;
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockStateHolder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockStateHolder.java
@@ -25,7 +25,7 @@ import com.sk89q.worldedit.registry.state.Property;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public interface BlockStateHolder<T extends BlockStateHolder> {
+public interface BlockStateHolder<B extends BlockStateHolder<B>> {
 
     /**
      * Get the block type
@@ -41,7 +41,7 @@ public interface BlockStateHolder<T extends BlockStateHolder> {
      * @param value The value
      * @return The modified state, or same if could not be applied
      */
-    <V> T with(final Property<V> property, final V value);
+    <V> B with(final Property<V> property, final V value);
 
     /**
      * Gets the value at the given state
@@ -64,7 +64,7 @@ public interface BlockStateHolder<T extends BlockStateHolder> {
      * @param o other block
      * @return true if equal
      */
-    boolean equalsFuzzy(BlockStateHolder o);
+    boolean equalsFuzzy(BlockStateHolder<?> o);
 
     /**
      * Returns an immutable {@link BlockState} from this BlockStateHolder.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
@@ -30,7 +30,6 @@ import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.item.ItemTypes;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
-import com.sk89q.worldedit.world.registry.BundledBlockData;
 import com.sk89q.worldedit.world.registry.LegacyMapper;
 
 import java.util.ArrayList;
@@ -49,7 +48,7 @@ public class BlockType {
     private final String id;
     private final Function<BlockState, BlockState> values;
     private final AtomicReference<BlockState> defaultState = new AtomicReference<>();
-    private final AtomicReference<Map<String, ? extends Property>> properties = new AtomicReference<>();
+    private final AtomicReference<Map<String, ? extends Property<?>>> properties = new AtomicReference<>();
     private final AtomicReference<BlockMaterial> blockMaterial = new AtomicReference<>();
     private final AtomicReference<Map<Map<Property<?>, Object>, BlockState>> blockStatesMap = new AtomicReference<>();
 
@@ -114,7 +113,7 @@ public class BlockType {
      *
      * @return The properties map
      */
-    public Map<String, ? extends Property> getPropertyMap() {
+    public Map<String, ? extends Property<?>> getPropertyMap() {
         return updateField(properties, () -> ImmutableMap.copyOf(WorldEdit.getInstance().getPlatformManager()
                 .queryCapability(Capability.GAME_HOOKS).getRegistries().getBlockRegistry().getProperties(this)));
     }
@@ -124,7 +123,7 @@ public class BlockType {
      *
      * @return the properties
      */
-    public List<? extends Property> getProperties() {
+    public List<? extends Property<?>> getProperties() {
         return ImmutableList.copyOf(this.getPropertyMap().values());
     }
 
@@ -135,7 +134,9 @@ public class BlockType {
      * @return The property
      */
     public <V> Property<V> getProperty(String name) {
-        Property<V> property = getPropertyMap().get(name);
+        // Assume it works, CCE later at runtime if not.
+        @SuppressWarnings("unchecked")
+        Property<V> property = (Property<V>) getPropertyMap().get(name);
         checkArgument(property != null, "%s has no property named %s", this, name);
         return property;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk.java
@@ -30,8 +30,8 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.DataException;
 import com.sk89q.worldedit.world.World;
+import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import com.sk89q.worldedit.world.registry.LegacyMapper;
 import com.sk89q.worldedit.world.storage.InvalidFormatException;
@@ -253,14 +253,14 @@ public class AnvilChunk implements Chunk {
     }
 
     @Override
-    public BlockStateHolder getBlock(BlockVector3 position) throws DataException {
+    public BaseBlock getBlock(BlockVector3 position) throws DataException {
         int id = getBlockID(position);
         int data = getBlockData(position);
 
         BlockState state = LegacyMapper.getInstance().getBlockFromLegacy(id, data);
         if (state == null) {
             WorldEdit.logger.warning("Unknown legacy block " + id + ":" + data + " found when loading legacy anvil chunk.");
-            return BlockTypes.AIR.getDefaultState();
+            return BlockTypes.AIR.getDefaultState().toBaseBlock();
         }
         CompoundTag tileEntity = getBlockTileEntity(position);
 
@@ -268,7 +268,7 @@ public class AnvilChunk implements Chunk {
             return state.toBaseBlock(tileEntity);
         }
 
-        return state;
+        return state.toBaseBlock();
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk13.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/AnvilChunk13.java
@@ -29,8 +29,8 @@ import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.world.DataException;
+import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import com.sk89q.worldedit.world.storage.InvalidFormatException;
@@ -229,7 +229,7 @@ public class AnvilChunk13 implements Chunk {
     }
 
     @Override
-    public BlockStateHolder getBlock(BlockVector3 position) throws DataException {
+    public BaseBlock getBlock(BlockVector3 position) throws DataException {
         int x = position.getX() - rootX * 16;
         int y = position.getY();
         int z = position.getZ() - rootZ * 16;
@@ -250,7 +250,7 @@ public class AnvilChunk13 implements Chunk {
             return state.toBaseBlock(tileEntity);
         }
 
-        return state;
+        return state.toBaseBlock();
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/Chunk.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/Chunk.java
@@ -21,13 +21,13 @@ package com.sk89q.worldedit.world.chunk;
 
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.DataException;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BaseBlock;
 
 /**
  * A 16 by 16 block chunk.
  */
 public interface Chunk {
-    
+
     /**
      * Get a block;
      *
@@ -35,6 +35,6 @@ public interface Chunk {
      * @return block the block
      * @throws DataException thrown on data error
      */
-    BlockStateHolder getBlock(BlockVector3 position) throws DataException;
+    BaseBlock getBlock(BlockVector3 position) throws DataException;
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/OldChunk.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/OldChunk.java
@@ -29,8 +29,8 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.DataException;
 import com.sk89q.worldedit.world.World;
+import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import com.sk89q.worldedit.world.registry.LegacyMapper;
 import com.sk89q.worldedit.world.storage.InvalidFormatException;
@@ -153,7 +153,7 @@ public class OldChunk implements Chunk {
     }
 
     @Override
-    public BlockStateHolder getBlock(BlockVector3 position) throws DataException {
+    public BaseBlock getBlock(BlockVector3 position) throws DataException {
         if(position.getY() >= 128) return BlockTypes.VOID_AIR.getDefaultState().toBaseBlock();
         int id, dataVal;
 
@@ -183,7 +183,7 @@ public class OldChunk implements Chunk {
         BlockState state = LegacyMapper.getInstance().getBlockFromLegacy(id, dataVal);
         if (state == null) {
             WorldEdit.logger.warning("Unknown legacy block " + id + ":" + dataVal + " found when loading legacy anvil chunk.");
-            return BlockTypes.AIR.getDefaultState();
+            return BlockTypes.AIR.getDefaultState().toBaseBlock();
         }
 
         CompoundTag tileEntity = getBlockTileEntity(position);
@@ -192,7 +192,7 @@ public class OldChunk implements Chunk {
             return state.toBaseBlock(tileEntity);
         }
 
-        return state;
+        return state.toBaseBlock();
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockRegistry.java
@@ -55,6 +55,6 @@ public interface BlockRegistry {
      * @param blockType the block
      * @return a map of states where the key is the state's ID
      */
-    Map<String, ? extends Property> getProperties(BlockType blockType);
+    Map<String, ? extends Property<?>> getProperties(BlockType blockType);
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockRegistry.java
@@ -48,7 +48,7 @@ public class BundledBlockRegistry implements BlockRegistry {
 
     @Nullable
     @Override
-    public Map<String, ? extends Property> getProperties(BlockType blockType) {
+    public Map<String, ? extends Property<?>> getProperties(BlockType blockType) {
         return Collections.emptyMap(); // Oof
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/LegacyMapper.java
@@ -155,7 +155,7 @@ public class LegacyMapper {
         return INSTANCE;
     }
 
-    @SuppressWarnings({"MismatchedQueryAndUpdateOfCollection", "unused"})
+    @SuppressWarnings({"MismatchedQueryAndUpdateOfCollection"})
     private static class LegacyDataFile {
         private Map<String, String> blocks;
         private Map<String, String> items;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/snapshot/Snapshot.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/snapshot/Snapshot.java
@@ -133,9 +133,10 @@ public class Snapshot implements Comparable<Snapshot> {
     public boolean containsWorld(String worldname) {
         try {
             if (file.getName().toLowerCase().endsWith(".zip")) {
-                ZipFile entry = new ZipFile(file);
-                return (entry.getEntry(worldname) != null
-                || entry.getEntry(worldname + "/level.dat") != null);
+                try (ZipFile entry = new ZipFile(file)) {
+                    return (entry.getEntry(worldname) != null
+                            || entry.getEntry(worldname + "/level.dat") != null);
+                }
             } else if (file.getName().toLowerCase().endsWith(".tar.bz2")
                     || file.getName().toLowerCase().endsWith(".tar.gz")
                     || file.getName().toLowerCase().endsWith(".tar")) {

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgePlayer.java
@@ -178,7 +178,7 @@ public class ForgePlayer extends AbstractPlayerActor {
     }
 
     @Override
-    public void sendFakeBlock(BlockVector3 pos, BlockStateHolder block) {
+    public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, B block) {
         BlockPos loc = ForgeAdapter.toBlockPos(pos);
         if (block == null) {
             // TODO

--- a/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
+++ b/worldedit-forge/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
@@ -169,7 +169,7 @@ public class ForgeWorld extends AbstractWorld {
     }
 
     @Override
-    public boolean setBlock(BlockVector3 position, BlockStateHolder block, boolean notifyAndLight) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block, boolean notifyAndLight) throws WorldEditException {
         checkNotNull(position);
         checkNotNull(block);
 
@@ -184,7 +184,6 @@ public class ForgeWorld extends AbstractWorld {
         IBlockState old = chunk.getBlockState(pos);
         Block mcBlock = Block.getBlockFromName(block.getBlockType().getId());
         IBlockState newState = mcBlock.getDefaultState();
-        @SuppressWarnings("unchecked")
         Map<Property<?>, Object> states = block.getStates();
         newState = applyProperties(mcBlock.getBlockState(), newState, states);
         IBlockState successState = chunk.setBlockState(pos, newState);

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongePlayer.java
@@ -35,6 +35,7 @@ import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.gamemode.GameMode;
 import com.sk89q.worldedit.world.gamemode.GameModes;
 import com.sk89q.worldedit.world.item.ItemTypes;
+
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.type.HandTypes;
 import org.spongepowered.api.entity.living.player.Player;
@@ -196,7 +197,7 @@ public class SpongePlayer extends AbstractPlayerActor {
     }
 
     @Override
-    public void sendFakeBlock(BlockVector3 pos, BlockStateHolder block) {
+    public <B extends BlockStateHolder<B>> void sendFakeBlock(BlockVector3 pos, B block) {
         org.spongepowered.api.world.Location<World> loc = player.getWorld().getLocation(pos.getX(), pos.getY(), pos.getZ());
         if (block == null) {
             player.sendBlockChange(loc.getBlockPosition(), loc.getBlock());

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorld.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/SpongeWorld.java
@@ -135,7 +135,7 @@ public abstract class SpongeWorld extends AbstractWorld {
     private static final BlockSnapshot.Builder builder = BlockSnapshot.builder();
 
     @Override
-    public boolean setBlock(BlockVector3 position, BlockStateHolder block, boolean notifyAndLight) throws WorldEditException {
+    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block, boolean notifyAndLight) throws WorldEditException {
         checkNotNull(position);
         checkNotNull(block);
 

--- a/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/adapter/SpongeImplLoader.java
+++ b/worldedit-sponge/src/main/java/com/sk89q/worldedit/sponge/adapter/SpongeImplLoader.java
@@ -85,7 +85,7 @@ public class SpongeImplLoader {
         Closer closer = Closer.create();
         JarFile jar = closer.register(new JarFile(file));
         try {
-            Enumeration entries = jar.entries();
+            Enumeration<JarEntry> entries = jar.entries();
             while (entries.hasMoreElements()) {
                 JarEntry jarEntry = (JarEntry) entries.nextElement();
 


### PR DESCRIPTION
Cleans up a lot of rawtypes in the API. This shouldn't be too big of a breaking change, all of the `BlockStateHolder`s that became `B extends BlockStateHolder` are binary-compatible changes, and all of the `BlockStateHolder`s that became `BaseBlock` or `BlockState` are also binary-compatible, since they're just more specific types.

There's a few other warning cleanups I put in for good measure.